### PR TITLE
fix(analyzer): analyzer.analyzeDate must return original maximum and minimum data

### DIFF
--- a/packages/datawizard/analyzer/__tests__/index.test.ts
+++ b/packages/datawizard/analyzer/__tests__/index.test.ts
@@ -304,9 +304,30 @@ test('date cols', () => {
   expect(d.type).toBe('integer');
   expect(d.recommendation).toBe('date');
   console.log(d);
-  expect(d.minimum).toBe(new Date('2019/01/01').getTime());
-  expect(d.maximum).toBe(new Date('2019/07/19').getTime());
+  expect(d.minimum).toBe('20190101');
+  expect(d.maximum).toBe('20190719');
 });
+
+test('date cols', () => {
+  const data = ['2019/01/01', '2019/01/02', '2019/01/03', '2019/07/16', '2019/07/17', '2019/07/18', '2019/07/19'];
+  const d = type(data);
+  expect(d.type).toBe('date');
+  expect(d.recommendation).toBe('date');
+  console.log(d);
+  expect(d.minimum).toBe('2019/01/01');
+  expect(d.maximum).toBe('2019/07/19');
+});
+
+test('date cols', () => {
+  const data = ['2019-01-01', '2019-01-02', '2019-01-03', '2019-07-16', '2019-07-17', '2019-07-18', '2019-07-19'];
+  const d = type(data);
+  expect(d.type).toBe('date');
+  expect(d.recommendation).toBe('date');
+  console.log(d);
+  expect(d.minimum).toBe('2019-01-01');
+  expect(d.maximum).toBe('2019-07-19');
+});
+
 test('date cols', () => {
   const data = [
     '20190101',
@@ -438,8 +459,8 @@ test('date cols', () => {
   expect(d.type).toBe('integer');
   expect(d.recommendation).toBe('date');
   console.log(d);
-  expect(d.minimum).toBe(new Date('2019/01/01').getTime());
-  expect(d.maximum).toBe(new Date('2019/01/02').getTime());
+  expect(d.minimum).toBe('20190101');
+  expect(d.maximum).toBe('20190102');
 });
 
 test('should return false if source is null in isDate method', () => {

--- a/packages/datawizard/analyzer/src/index.ts
+++ b/packages/datawizard/analyzer/src/index.ts
@@ -95,9 +95,9 @@ export interface NumberFieldInfo extends FieldInfo {
  */
 export interface DateFieldInfo extends FieldInfo {
   /** minimum date */
-  minimum: number;
+  minimum: string | number | Date;
   /** maximum date */
-  maximum: number;
+  maximum: string | number | Date;
 }
 
 /**
@@ -185,8 +185,8 @@ function analyzeDate(array: Array<string | Date>, isInteger = false): Omit<DateF
     return new Date(item).getTime();
   });
   return {
-    minimum: Stat.min(list),
-    maximum: Stat.max(list),
+    minimum: array[Stat.minIndex(list)],
+    maximum: array[Stat.maxIndex(list)],
   };
 }
 

--- a/packages/datawizard/analyzer/src/statistic.ts
+++ b/packages/datawizard/analyzer/src/statistic.ts
@@ -24,6 +24,52 @@ export function max(array: number[]): number {
 }
 
 /**
+ * Return the minimum index of the array
+ * @param array - The array to process
+ * @public
+ */
+export function minIndex(array: number[]): number {
+  const value = cache.get<number>(array, 'minIndex');
+  if (value !== undefined) return value;
+  return cache.set(array, 'minIndex', minIdx(array));
+}
+
+function minIdx(array: number[]) {
+  let min = array[0];
+  let idx = 0;
+  for (const key in array) {
+    if (array[key] < min) {
+      idx = Number(key);
+      min = array[key];
+    }
+  }
+  return idx;
+}
+
+/**
+ * Return the maximum index of the array
+ * @param array - The array to process
+ * @public
+ */
+export function maxIndex(array: number[]): number {
+  const value = cache.get<number>(array, 'maxIndex');
+  if (value !== undefined) return value;
+  return cache.set(array, 'maxIndex', maxIdx(array));
+}
+
+function maxIdx(array: number[]) {
+  let max = array[0];
+  let idx = 0;
+  for (const key in array) {
+    if (array[key] > max) {
+      idx = Number(key);
+      max = array[key];
+    }
+  }
+  return idx;
+}
+
+/**
  * Return the sum of the array
  * @param array - The array to process
  * @public


### PR DESCRIPTION
According to the general design logic, the original data should be returned after an array gets the maximum and minimum value.  So analyzer.analyzeDate in package datawizard should return original value of maximum and minimum, not the timestamp.

It's related to #24.