### PR TITLE
fix(chart-advisor): uninitialize noDataLayer

### DIFF
--- a/packages/chart-advisor/src/auto-chart.ts
+++ b/packages/chart-advisor/src/auto-chart.ts
@@ -128,7 +128,7 @@ export class AutoChart {
     this.isMocked = false;
     this.options = options || {};
     const { fields, development, noDataContent } = this.options;
-    this.noDataLayer = createLayer(container);
+    this.noDataLayer = createLayer(this.container);
     this.noDataContent = noDataContent || DEFAULT_FEEDBACK('暂无数据');
     this.data = fields && fields.length > 0 ? data.map((item) => pick(item, fields)) : data;
     this.development =

--- a/packages/chart-advisor/src/auto-chart.ts
+++ b/packages/chart-advisor/src/auto-chart.ts
@@ -128,6 +128,7 @@ export class AutoChart {
     this.isMocked = false;
     this.options = options || {};
     const { fields, development, noDataContent } = this.options;
+    this.noDataLayer = createLayer(container);
     this.noDataContent = noDataContent || DEFAULT_FEEDBACK('暂无数据');
     this.data = fields && fields.length > 0 ? data.map((item) => pick(item, fields)) : data;
     this.development =


### PR DESCRIPTION
重复调用 autoChart 时，destroy noDataLayer 后未初始化，导致再次调用 destroy 失败。