### PR TITLE
feat: add table advice spec

### DIFF
--- a/common/reviews/api/chart-advisor.api.md
+++ b/common/reviews/api/chart-advisor.api.md
@@ -18,7 +18,7 @@ export interface Advice {
     // (undocumented)
     score: number;
     // (undocumented)
-    spec: Specification | null;
+    spec: Specification | TableDataCfg | null;
     // (undocumented)
     type: ChartID;
 }
@@ -324,6 +324,16 @@ export function specRender(container: string | HTMLElement, data: any[], spec: A
 
 // @public (undocumented)
 export type StackType = 'zero' | 'center' | 'normalize' | null | boolean;
+
+// @public (undocumented)
+export interface TableDataCfg {
+    // (undocumented)
+    columns: string[];
+    // (undocumented)
+    rows: string[];
+    // (undocumented)
+    values: string[];
+}
 
 // @public (undocumented)
 export type Validator = (args: Info) => number;

--- a/packages/chart-advisor/__tests__/unit/pipeline/data-to-specs.test.ts
+++ b/packages/chart-advisor/__tests__/unit/pipeline/data-to-specs.test.ts
@@ -91,7 +91,11 @@ describe('API - dataToAdvices', () => {
         },
         {
           score: 1,
-          spec: null,
+          spec: {
+            columns: [],
+            rows: ['city'],
+            values: ['value'],
+          },
           type: 'table',
         },
       ]);

--- a/packages/chart-advisor/__tests__/unit/pipeline/dataprops-to-advices.test.ts
+++ b/packages/chart-advisor/__tests__/unit/pipeline/dataprops-to-advices.test.ts
@@ -137,7 +137,11 @@ describe('API - dataPropsToAdvices', () => {
         },
         {
           score: 1,
-          spec: null,
+          spec: {
+            columns: [],
+            rows: ['city'],
+            values: ['value'],
+          },
           type: 'table',
         },
       ]);

--- a/packages/chart-advisor/src/advice-pipeline/dataprops-to-advices.ts
+++ b/packages/chart-advisor/src/advice-pipeline/dataprops-to-advices.ts
@@ -82,8 +82,8 @@ export function dataPropsToAdvices(dataProps: DataProperty[], options?: AdvisorO
 
     // step 3: apply design rules
     if (chartTypeSpec && enableRefine) {
-      const encodingSpecs = applyDesignRules(t, dataProps, chartTypeSpec);
-      deepMix(chartTypeSpec.encoding, encodingSpecs);
+      const encodingSpecs = applyDesignRules(t, dataProps, chartTypeSpec as SingleViewSpec);
+      deepMix((chartTypeSpec as SingleViewSpec).encoding, encodingSpecs);
       // return { type: t, spec: chartTypeSpec, score }
     }
 

--- a/packages/chart-advisor/src/advice-pipeline/interface.ts
+++ b/packages/chart-advisor/src/advice-pipeline/interface.ts
@@ -81,13 +81,22 @@ export type VegaLiteSubsetSpec = SingleViewSpec | { layer: SingleViewSpec[] };
 export type Specification = SingleViewSpec;
 
 /**
+ * @public
+ */
+export interface TableDataCfg {
+  rows: string[];
+  values: string[];
+  columns: string[];
+}
+
+/**
  * return type of data props to spec
  * @public
  */
 export interface Advice {
   type: ChartID;
   // 如果有推荐有效图表，必须提规范信息，可能是 vegalite spec 也可能是 custom spec（用于 指标卡和交叉表）
-  spec: Specification | null;
+  spec: Specification | TableDataCfg | null;
   score: number;
 }
 

--- a/packages/chart-advisor/src/advice-pipeline/spec-mapping.ts
+++ b/packages/chart-advisor/src/advice-pipeline/spec-mapping.ts
@@ -49,7 +49,7 @@ export function getChartTypeSpec(chartType: ChartID, dataProps: DataProperty[]):
     case 'kpi_panel':
       return kpi_panel();
     case 'table':
-      return table();
+      return table(dataProps);
     default:
       return null;
   }
@@ -510,7 +510,22 @@ function kpi_panel(): Advice['spec'] {
   return null;
 }
 
-function table(): Advice['spec'] {
-  // TODO 交叉表暂不做更细致的配置，只支持基本的数值显示
-  return null;
+function table(dataProps: DataProperty[]): Advice['spec'] {
+  const values = [];
+  const rows = [];
+
+  for (let i = 0; i < dataProps.length; i++) {
+    const field = dataProps[i];
+    if (intersects(field.levelOfMeasurements, ['Interval', 'Continuous', 'Discrete'])) {
+      values.push(field.name);
+    } else {
+      rows.push(field.name);
+    }
+  }
+
+  return {
+    rows,
+    values,
+    columns: [],
+  };
 }


### PR DESCRIPTION
新增 chartType 为 table 时的 spec，目前包括配置项有
* rows 行头
* columns 列头
* values 值字段