### PR TITLE
Remove comparison purpose of stacked area chart

### DIFF
--- a/common/reviews/api/dw-transform.api.md
+++ b/common/reviews/api/dw-transform.api.md
@@ -206,7 +206,7 @@ export interface TransformSchema {
     groupBy?: string[];
 }
 
-// @public (undocumented)
+// @public
 export function unstack(data: RowData[], field: string, values: string[]): RowData[];
 
 

--- a/packages/datawizard/transform/src/reshape/stack.ts
+++ b/packages/datawizard/transform/src/reshape/stack.ts
@@ -4,8 +4,8 @@ import { xor, keys, compact, pick } from 'lodash';
 /**
  * Pivot specific field of each values.
  * @public
- * @param {string} field field
- * @param {string} values unstack  values
+ * @param field - field
+ * @param values - unstack  values
  * @returns row datas
  */
 export function unstack(data: RowData[], field: string, values: string[]): RowData[] {

--- a/packages/knowledge/src/base.ts
+++ b/packages/knowledge/src/base.ts
@@ -67,7 +67,7 @@ export const base: ChartKnowledgeBase = {
     family: ['AreaCharts'],
     def:
       'A stacked area chart uses layered line segments with different styles of padding regions to display how multiple sets of data change in the same ordinal dimension, and the endpoint heights of the segments on the same dimension tick are accumulated by value.',
-    purpose: ['Comparison', 'Composition', 'Trend'],
+    purpose: ['Composition', 'Trend'],
     coord: ['Cartesian2D'],
     category: ['Statistic'],
     shape: ['Area'],


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed - staked area chart is not suitable for comparison purpose
- [ ] add / modify test cases
- [ ] documents, demos - run bootstrap again, fix some api extractor warning
