### PR TITLE
fix(chart-advisor): config panel disappear

### DIFF
--- a/demo/AutoChartTest.tsx
+++ b/demo/AutoChartTest.tsx
@@ -280,9 +280,15 @@ const chartRuleConfigs = {
 export function AutoChartTest() {
   return (
     <>
-      <AutoChart data={data2} refine={false} title="custom" />
-      <AutoChart data={pieData} chartRuleConfigs={chartRuleConfigs} refine={false} title="custom rule configs" />
-      <AutoChart data={data} title="Design rule: 'x-axis-line-fading'" />
+      <AutoChart data={data2} refine={false} title="custom" development={false} language="zh-CN" />
+      <AutoChart
+        data={pieData}
+        chartRuleConfigs={chartRuleConfigs}
+        refine={false}
+        title="custom rule configs"
+        language="en-US"
+      />
+      <AutoChart data={data} title="Design rule: 'x-axis-line-fading'" development={false} />
       {/* <AutoChart
         data={[
           {
@@ -317,6 +323,7 @@ export function AutoChartTest() {
           { f1: 'd', f2: 630 },
         ]}
         title="expect: Pie"
+        language="zh-CN"
       />
 
       {/* <AutoChart data={[]} title="测试" description="测试" /> */}

--- a/packages/chart-advisor/__tests__/bugs/config-panel-disappear.test.ts
+++ b/packages/chart-advisor/__tests__/bugs/config-panel-disappear.test.ts
@@ -1,0 +1,22 @@
+// 2021-05-21 清妤(Amy) feedback
+import { autoChart } from '../../src';
+import { createDiv } from '../utils/dom';
+import { wait } from '../utils/wait';
+
+describe('config penal disappear', () => {
+  it('auto chart', async () => {
+    const div = createDiv('ColumnCharts');
+    div.style.height = '400px';
+    div.style.boxSizing = 'border-box';
+    const data = [
+      { city: 'a', gender: 'w', amount: 12 },
+      { city: 'b', gender: 'w', amount: 14 },
+      { city: 'b', gender: 'm', amount: 4 },
+      { city: 'c', gender: 'w', amount: 18 },
+    ];
+    await autoChart(div, data, { toolbar: false, development: true });
+    await wait();
+    const panelHandlerDom = div.querySelector('.__AUTO_CHART__config_btn');
+    expect(panelHandlerDom).toBeTruthy();
+  });
+});

--- a/packages/chart-advisor/__tests__/bugs/issue-116.test.ts
+++ b/packages/chart-advisor/__tests__/bugs/issue-116.test.ts
@@ -21,7 +21,7 @@ const data2 = [
   { region: 'NorthWest', sales: 1303.5 },
 ];
 
-function clickBtn(div, data, ms) {
+function clickBtn(div: HTMLDivElement, data: any, ms: number) {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       try {
@@ -35,18 +35,18 @@ function clickBtn(div, data, ms) {
 
 describe('multiple execution errors', () => {
   it('', async () => {
-    const div = createDiv('ColumnCharts');
+    const div = createDiv('multiple exec');
     div.style.height = '400px';
     div.style.boxSizing = 'border-box';
 
     autoChart(div, data1, { toolbar: false, development: true });
 
-    const click1 = await clickBtn(div, data2, 100);
+    const click1 = await clickBtn(div, data2, 10);
     // @ts-ignore
     const plot = click1.getPlot();
     expect((plot as any).data[2].sales).toBe(data2[2].sales);
 
-    const click2 = await clickBtn(div, data1, 200);
+    const click2 = await clickBtn(div, data1, 20);
     // @ts-ignore
     const plot = click2.getPlot();
     expect((plot as any).data[2].sales).toBe(data1[2].sales);

--- a/packages/chart-advisor/__tests__/utils/dom.ts
+++ b/packages/chart-advisor/__tests__/utils/dom.ts
@@ -3,7 +3,7 @@
  * @param title
  * @param container
  */
-export function createDiv(title?: string, container: HTMLElement = document.body): HTMLElement {
+export function createDiv(title?: string, container: HTMLElement = document.body): HTMLDivElement {
   const div = document.createElement('div');
 
   if (title) {

--- a/packages/chart-advisor/__tests__/utils/wait.ts
+++ b/packages/chart-advisor/__tests__/utils/wait.ts
@@ -1,0 +1,10 @@
+/**
+ * make test async
+ */
+export async function wait(ms?: number) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve('');
+    }, ms || 0);
+  });
+}

--- a/packages/chart-advisor/src/auto-chart/auto-chart.ts
+++ b/packages/chart-advisor/src/auto-chart/auto-chart.ts
@@ -1,4 +1,4 @@
-import { merge, cloneDeep } from 'lodash';
+import { merge } from 'lodash';
 import { isEqual, pick } from '@antv/util';
 import { ConfigPanel } from './config-panel';
 import { Toolbar } from './toolbar';
@@ -170,7 +170,7 @@ export class AutoChart {
     if (this.rendered) this.destroy();
     this.rendered = true;
     // this.isMocked = false;
-    this.options = merge(cloneDeep(defaultOptions), options) || {};
+    this.options = merge({}, defaultOptions, options);
     const { fields, development, noDataContent, language } = this.options;
     if (!this.noDataLayer) this.noDataLayer = createLayer(this.container, 'no-data-layer');
     this.noDataContent = noDataContent || DEFAULT_FEEDBACK(intl.get('No Recommendation'));
@@ -229,12 +229,16 @@ export class AutoChart {
         this.toolbar = new Toolbar(this.plot, this.container);
       }
     }
-    if (development && this.plot.plot) {
-      // configPanel not supported kpi_panel and table temporary
-      if (!customChartType.includes(this.plot?.type || '')) {
-        this.configPanel = new ConfigPanel(this.plot, this.isMocked, this.container);
+    // plot instance is async render due to import g2plot using webpackChunkName
+    // make this judge(this.plot.plot) in next event loop
+    setTimeout(() => {
+      if (development && this.plot?.plot) {
+        // configPanel not supported kpi_panel and table temporary
+        if (!customChartType.includes(this.plot?.type || '')) {
+          this.configPanel = new ConfigPanel(this.plot, this.isMocked, this.container, this.options.language);
+        }
       }
-    }
+    });
   }
 
   /**

--- a/packages/chart-advisor/src/auto-chart/config-panel.ts
+++ b/packages/chart-advisor/src/auto-chart/config-panel.ts
@@ -88,7 +88,7 @@ export class ConfigPanel {
     trigger.addEventListener('click', () => {
       if (!this.panel) {
         this.panel = new DevPanel({
-          title: intl.get('Chart Config'),
+          title: intl.get('Chart Config', this.language),
           height: 534,
           width: 340,
           ...getPosition(this.chartContainer),

--- a/packages/chart-advisor/src/auto-chart/config-panel.ts
+++ b/packages/chart-advisor/src/auto-chart/config-panel.ts
@@ -4,7 +4,7 @@ import { AutoPlot } from './auto-plot';
 import { DummyPlot } from './dummy-plot';
 import { translate, getPosition } from '../util';
 import { DevPanel } from './dev-panel';
-import { intl, getLanguage } from '../i18n';
+import { intl, getLanguage, Language } from '../i18n';
 
 const SEND_CONFIGS = '__advisor__.send_configs';
 const CONFIGS_CHANGE = '__advisor__.configs_change';
@@ -45,6 +45,11 @@ export class ConfigPanel {
    */
   panel?: DevPanel;
 
+  /**
+   * i18n
+   */
+  language: Language;
+
   private messageHandler = (e: MessageEvent) => {
     const { uuid, plot } = this.plotInst;
     if (e.data && e.data.type === CONFIGS_CHANGE && e.data.uuid === uuid) {
@@ -63,10 +68,11 @@ export class ConfigPanel {
     this.trigger.style.display = 'none';
   };
 
-  constructor(plotInst: AutoPlot | DummyPlot, needCopyData: boolean, container: HTMLElement) {
+  constructor(plotInst: AutoPlot | DummyPlot, needCopyData: boolean, container: HTMLElement, language?: Language) {
     this.plotInst = plotInst;
     this.needCopyData = needCopyData;
     this.chartContainer = container;
+    this.language = language || getLanguage();
     container.addEventListener('mouseenter', this.mouseEnterHandler);
     container.addEventListener('mouseleave', this.mouseLeaveHandler);
     this.initIframe();
@@ -136,6 +142,6 @@ export class ConfigPanel {
     if (type)
       this.iframe.src = `${PATH_PREFIX}/config-panel.html?type=${translate(type)}&cancopydata=${
         this.needCopyData
-      }&lang=${getLanguage()}`;
+      }&lang=${this.language}`;
   }
 }

--- a/packages/chart-advisor/src/i18n/index.ts
+++ b/packages/chart-advisor/src/i18n/index.ts
@@ -5,9 +5,9 @@ export type Language = 'en-US' | 'zh-CN';
 
 let defaultLanguage: Language | undefined = undefined;
 
-const transformLanguage = (lang: string) => {
+const transformLanguage = (language: string) => {
   // If the language starts with "zh", it is "zh-CN" by default,
-  if (lang && lang === 'zh-CN') return lang;
+  if (language && language === 'zh-CN') return language;
   // otherwise, it will be "en_US".
   return 'en-US';
 };
@@ -23,7 +23,11 @@ export const setLanguage = (language: Language | undefined) => {
 };
 
 export const intl = {
-  get: (key: string) => {
-    return _get({ en_US, zh_CN }, [getLanguage().replace('-', '_'), key], key);
+  get: (key: string, language?: string) => {
+    return _get(
+      { en_US, zh_CN },
+      [language ? transformLanguage(language).replace('-', '_') : getLanguage().replace('-', '_'), key],
+      key
+    );
   },
 };


### PR DESCRIPTION
### Chart Advisor Package
- fix: config panel disappear and add a test case
- fix: panel language use option rather than `getLanguage`