### PR TITLE
fix: the first three digits of phone numbers can be specified

### DIFF
--- a/packages/datawizard/random/__tests__/text-random.test.ts
+++ b/packages/datawizard/random/__tests__/text-random.test.ts
@@ -19,9 +19,22 @@ test('character111', () => {
   expect(R.phone({ mobile: false, formatted: true })).toMatch(/\d{3,4}-\d{7,8}/);
   expect(R.phone({ mobile: false })).toMatch(/\d{10,12}/);
   expect(R.phone({ formatted: true, asterisk: true })).toMatch(/1[345789]\d-\*{4}-\d{4}/);
-  expect(R.phone({ asterisk: true })).toMatch(/1[345789]\d{2}\*{4}\d{4}/);
+  expect(R.phone({ asterisk: true })).toMatch(/1[345789]\d\*{4}\d{4}/);
   expect(R.phone({ mobile: false, formatted: true, asterisk: true })).toMatch(/\d{3,4}-\d{3}\*{2,3}\d{2}/);
   expect(R.phone({ mobile: false, asterisk: true })).toMatch(/\d{3,4}\d{3}\*{2,3}\d{2}/);
+  expect(R.phone({ formatted: true, startNum: '182' })).toMatch(new RegExp('182' + '-\\d{4}-\\d{4}'));
+  expect(R.phone({ startNum: '144' })).toMatch(new RegExp('144' + '\\d{8}'));
+  expect(R.phone({ mobile: false, formatted: true, startNum: '021' })).toMatch(new RegExp('021' + '-\\d{7,8}'));
+  expect(R.phone({ mobile: false, startNum: '010' })).toMatch(new RegExp('010' + '\\d{7,8}'));
+  expect(R.phone({ formatted: true, asterisk: true, startNum: '143' })).toMatch(new RegExp('143' + '-\\*{4}-\\d{4}'));
+  expect(R.phone({ asterisk: true, startNum: '13' })).toMatch(/1[345789]\d\*{4}\d{4}/);
+  expect(R.phone({ asterisk: true, startNum: '186' })).toMatch(new RegExp('186' + '\\*{4}\\d{4}'));
+  expect(R.phone({ mobile: false, formatted: true, asterisk: true, startNum: '010' })).toMatch(
+    new RegExp('010' + '-\\d{3}\\*{2,3}\\d{2}')
+  );
+  expect(R.phone({ mobile: false, asterisk: true, startNum: '010' })).toMatch(
+    new RegExp('010' + '\\d{3}\\*{2,3}\\d{2}')
+  );
   expect(R.name()).toContain(' ');
   expect(R.cname()).not.toContain(' ');
   expect(R.clastname({ length: 3 })).toHaveLength(3);

--- a/packages/datawizard/random/src/text-random.ts
+++ b/packages/datawizard/random/src/text-random.ts
@@ -248,16 +248,38 @@ export class TextRandom extends BasicRandom {
    * @param options - the params
    */
   phone(options?: PhoneOptions): string {
-    const { mobile, formatted, asterisk } = initOptions(options, { mobile: true, formatted: false, asterisk: false });
+    const { mobile, formatted, asterisk, startNum } = initOptions(options, {
+      mobile: true,
+      formatted: false,
+      asterisk: false,
+      startNum: '',
+    });
     let exp: RegExp;
     if (mobile) {
-      // add '****' in mobile numbers
-      if (asterisk) exp = formatted ? /1[345789]\d-\*{4}-\d{4}/ : /1[345789]\d{2}\*{4}\d{4}/;
-      else exp = formatted ? /1[345789]\d-\d{4}-\d{4}/ : /1[345789]\d{9}/;
+      // add **** in mobile numbers
+      if (asterisk) {
+        // specify the first three digits
+        if (startNum.length == 3)
+          exp = formatted ? new RegExp(startNum + '-\\*{4}-\\d{4}') : new RegExp(startNum + '\\*{4}\\d{4}');
+        else exp = formatted ? /1[345789]\d-\*{4}-\d{4}/ : /1[345789]\d\*{4}\d{4}/;
+      } else {
+        if (startNum.length == 3)
+          exp = formatted ? new RegExp(startNum + '-\\d{4}-\\d{4}') : new RegExp(startNum + '\\d{8}');
+        else exp = formatted ? /1[345789]\d-\d{4}-\d{4}/ : /1[345789]\d{9}/;
+      }
     } else {
-      // add '**' or '***' in landline numbers
-      if (asterisk) exp = formatted ? /\d{3,4}-\d{3}\*{2,3}\d{2}/ : /\d{3,4}\d{3}\*{2,3}\d{2}/;
-      else exp = formatted ? /\d{3,4}-\d{7,8}/ : /\d{10,12}/;
+      // add ** or *** in landline numbers
+      if (asterisk) {
+        if (startNum.length == 3)
+          exp = formatted
+            ? new RegExp(startNum + '-\\d{3}\\*{2,3}\\d{2}')
+            : new RegExp(startNum + '\\d{3}\\*{2,3}\\d{2}');
+        else exp = formatted ? /\d{3,4}-\d{3}\*{2,3}\d{2}/ : /\d{3,4}\d{3}\*{2,3}\d{2}/;
+      } else {
+        if (startNum.length == 3)
+          exp = formatted ? new RegExp(startNum + '-\\d{7,8}') : new RegExp(startNum + '\\d{7,8}');
+        else exp = formatted ? /\d{3,4}-\d{7,8}/ : /\d{10,12}/;
+      }
     }
     return this.randexp(exp);
   }
@@ -357,6 +379,8 @@ export interface PhoneOptions {
   formatted?: boolean;
   /** true: add '*' to avoid generating real phone numbers */
   asterisk?: boolean;
+  /** only the first three digits can be specified, otherwise it is invalid */
+  startNum?: string;
 }
 
 /** @public */


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #173 
- [x] add / modify test cases
- [ ] documents, demos

1. fix the wrong length of mobile numbers when asterisks added
2. the first three digits can be specified, otherwise the param is invalid
