### PR TITLE
chore: fix @babel/runtime module find error

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
-    "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
@@ -39,7 +38,6 @@
     "@antv/g2": "^4.0.15",
     "@antv/g2plot": "^2.0.9",
     "@antv/thumbnails": "^1.3.0",
-    "@babel/runtime": "^7.8.7",
     "antd": "^4.8.0",
     "csstype": "^3.0.5",
     "lodash": "^4.17.20",

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -29,9 +29,8 @@ const devConfig = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         options: {
-          presets: ['@babel/preset-typescript', ['@babel/preset-env', { modules: 'commonjs' }], '@babel/preset-react'],
+          presets: ['@babel/preset-typescript', ['@babel/preset-env', { modules: false }], '@babel/preset-react'],
           plugins: [
-            '@babel/plugin-transform-runtime',
             '@babel/plugin-proposal-class-properties',
             '@babel/plugin-proposal-object-rest-spread',
           ],


### PR DESCRIPTION
When we start demo, we will find some errors like `Module not found: Error: Can't resolve '@babel/runtime/helpers/typeof' in 'AVA/packages/data-wizard/esm/analyzer'`.

The reason is lerna's symlink npm package is considered as relative path instead of `node_modules` by babel. Packages' files will be resolved by babel. And node will find `@babel/runtime` from inner to outer. There is no `@babel/runtime` in `data-wizard`, and no `@babel/runtime` in root. It only exists in `demo`.

There was no such issue in v1 because we put `webpack.config.js` and related packages in root.

So........ We can solve the issue in the following two ways:
- Move @babel/runtime devDep from demo to root.
- Remove `@babel/plugin-transform-runtime` and `@babel/runtime`. In fact, we don't have to support ES5 in demo.

This PR chooses method one.