### PR TITLE
feat(DW): allow slice during constructing

### DIFF
--- a/packages/data-wizard/__tests__/dataset/data-frame.test.ts
+++ b/packages/data-wizard/__tests__/dataset/data-frame.test.ts
@@ -134,6 +134,31 @@ describe('New DataFrame', () => {
       [0, 1],
     ]);
   });
+
+  test('2D: object in array slice', () => {
+    const df = new DataFrame([
+      { a: 1, b: 4, c: 7 },
+      { a: 2, b: 5, c: 8 },
+      { a: 3, b: 6, c: 9 },
+    ], { columns: ['a', 'c'] });
+
+    // console.log('2D: object in array slice');
+    // console.log(df);
+
+    expect(df.data).toStrictEqual([
+      [1, 7],
+      [2, 8],
+      [3, 9],
+    ]);
+    expect(df.colData).toStrictEqual([
+      [1, 2, 3],
+      [7, 8, 9],
+    ]);
+    expect(df.axes).toStrictEqual([
+      [0, 1, 2],
+      ['a', 'c'],
+    ]);
+  });
 });
 
 describe('DataFrame Get Value Functions', () => {
@@ -358,19 +383,15 @@ describe('DataFrame Get Value Functions', () => {
   });
 });
 
-// describe('New DataFrame', () => {
+// describe('DataFrame Info', () => {
 //   test('2D: object in array', () => {
-//     // const df = new DataFrame([
-//     //   { a: 1, b: 4, c: 7 },
-//     //   { a: 2, b: 5, c: 8 },
-//     //   { a: 3, b: 6, c: 9 },
-//     // ], { columns: ['a', 'c'] });
 //     const df = new DataFrame([
 //       { a: 1, b: 4, c: 7 },
 //       { a: 2, b: 5, c: 8 },
 //       { a: 3, b: 6, c: 9 },
-//     ]);
+//     ], { columns: ['a', 'c'] });
 
+//     console.log('df', df);
 //     console.log('df.info', df.info());
 //   });
 // });

--- a/packages/data-wizard/src/dataset/data-frame.ts
+++ b/packages/data-wizard/src/dataset/data-frame.ts
@@ -23,9 +23,33 @@ export default class DataFrame extends BaseFrame {
 
       // 2D: object in array
       if (utils.isObject(data0)) {
-        const columns = Object.keys(data0);
-        this.genDataAndColDataFromArr(true, data, columns);
-        this.genColumns(columns, extra);
+        const columns: Axis[] = Object.keys(data0);
+        // slice
+        if (extra?.columns && extra?.columns.length < columns.length) {
+          for (let i = 0; i < data.length; i += 1) {
+            const datum = data[i];
+            this.data[i] = [];
+            for (let j = 0; j < extra.columns.length; j += 1) {
+              const column = extra.columns[j];
+              if (columns.includes(column)) {
+                this.data[i].push(datum[column]);
+              } else {
+                throw new Error(`There is no column ${column} in data.`);
+              }
+
+              if (this.colData[j]) {
+                this.colData[j].push(datum[column]);
+              } else {
+                this.colData[j] = [datum[column]];
+              }
+            }
+          }
+
+          this.setAxis(1, extra.columns);
+        } else {
+          this.genDataAndColDataFromArr(true, data, columns);
+          this.genColumns(columns, extra);
+        }
       }
 
       // 2D: array
@@ -93,7 +117,6 @@ export default class DataFrame extends BaseFrame {
         throw new Error(`Columns length is ${extra.columns?.length}, but data size is ${columns.length}`);
       }
     } else {
-      // convert Map Iterator to array
       this.setAxis(1, columns);
     }
   };


### PR DESCRIPTION
You can use extra.columns to slice data during constructing. The feature only works for (2D) object in array.

Be like
```
const df = new DataFrame([
    { a: 1, b: 4, c: 7 },
    { a: 2, b: 5, c: 8 },
    { a: 3, b: 6, c: 9 },
], { columns: ['a', 'c'] });
```