### PR TITLE
feat(CA): linter and chart-advisor

### DIFF
--- a/packages/chart-advisor/__tests__/index.test.ts
+++ b/packages/chart-advisor/__tests__/index.test.ts
@@ -162,18 +162,55 @@ describe('init Advisor', () => {
 });
 
 describe('init Linter', () => {
-  test('Linter', () => {
-    // TODO param and output
+  const errorSpec = {
+    'basis': {
+      'type': 'chart'
+    },
+    'data': {
+      'type': 'json-array',
+      'values': [
+        { 'year': '2007', 'sales': 28 },
+        { 'year': '2008', 'sales': 55 },
+        { 'year': '2009', 'sales': 43 },
+        { 'year': '2010', 'sales': 91 },
+        { 'year': '2011', 'sales': 81 },
+        { 'year': '2012', 'sales': 53 },
+        { 'year': '2013', 'sales': 19 },
+        { 'year': '2014', 'sales': 87 },
+        { 'year': '2015', 'sales': 52 }
+      ]
+    },
+    'layer': [
+      {
+        'mark': 'area',
+        'encoding': {
+          'x': {
+            'field': 'year',
+            'type': 'temporal'
+          },
+          'y': {
+            'field': 'sales',
+            'type': 'quantitative'
+          }
+        }
+      }
+    ]
+  };
+
+  test('Linter test 1', () => {
     const myLt = new Linter();
-    const errors = myLt.lint({});
-    expect(errors.length).toBe(0);
+    const errors = myLt.lint(errorSpec as AntVSpec);
+    // FIXME: actual test after rule definition otimization
+    expect(errors.length).toBe(2);
   });
 });
 
 describe('init ChartAdvisor', () => {
   // TODO formal test
-  test('dataToAdvices in CA', () => {
+  test('adviseWithLint in CA', () => {
     const myCA = new ChartAdvisor();
-    expect(myCA.dataToAdvices([])).toBe('dataToAdvices in CA.');
+    const results = myCA.advise(data, ['price', 'type'], { refine: true });
+    // FIXME: actual test after rule definition otimization
+    expect(results.length).toBe(4);
   });
 });

--- a/packages/chart-advisor/src/advisor/advice-pipeline/index.ts
+++ b/packages/chart-advisor/src/advisor/advice-pipeline/index.ts
@@ -1,2 +1,3 @@
 export * from './data-to-advices';
 export * from './spec-mapping';
+export * from './interface';

--- a/packages/chart-advisor/src/advisor/advice-pipeline/spec-mapping.ts
+++ b/packages/chart-advisor/src/advisor/advice-pipeline/spec-mapping.ts
@@ -374,8 +374,8 @@ function columnChart(data: DataRows, dataProps: BasicDataPropertyForAdvice[]): A
       {
         mark: { type: 'bar' },
         encoding: {
-          x: { field: field4Y.name, type: 'nominal' },
-          y: { field: field4X.name, type: 'quantitative' },
+          x: { field: field4X.name, type: 'nominal' },
+          y: { field: field4Y.name, type: 'quantitative' },
         },
       },
     ],

--- a/packages/chart-advisor/src/advisor/index.ts
+++ b/packages/chart-advisor/src/advisor/index.ts
@@ -4,6 +4,7 @@ import { RuleConfig, RuleModule } from '../ruler/concepts/rule';
 import { BasicDataPropertyForAdvice, processRuleCfg } from '../ruler';
 import { dataToAdvices } from './advice-pipeline/data-to-advices';
 import { CKBConfig } from './ckb-config';
+import { AdvisorOptions } from './advice-pipeline/interface';
 
 export class Advisor {
   /**
@@ -40,7 +41,7 @@ export class Advisor {
    * @param options advice options such as purpose
    * @returns advice list
    */
-  advise(data: Record<string, any>[], fields?: string[], options?: any) {
+  advise(data: Record<string, any>[], fields?: string[], options?: AdvisorOptions) {
     // transform data into DataFrame
     let dataFrame: DataFrame;
     try {
@@ -112,3 +113,4 @@ export class Advisor {
 }
 
 export * from './advice-pipeline';
+export * from './ckb-config';

--- a/packages/chart-advisor/src/chart-advisor/index.ts
+++ b/packages/chart-advisor/src/chart-advisor/index.ts
@@ -1,11 +1,39 @@
-export class ChartAdvisor {
-  // advisor + linter together
-  // TODO implementation
+import { RuleConfig } from '../ruler/concepts/rule';
+import { Advisor, CKBConfig, AdvisorOptions } from '../advisor';
+import { Linter } from '../linter';
 
-  dataToAdvices(data: any[], fields?: string[]) {
-    if (data || fields) {
-      return 'dataToAdvices in CA.';
-    }
-    return 'dataToAdvices in CA.';
+export class ChartAdvisor {
+  /**
+   * @private Advisor instance
+   */
+  private advisor: Advisor;
+
+  /**
+   * @private Linter instance
+   */
+  private linter: Linter;
+
+  constructor(ckbCfg?: CKBConfig, ruleCfg?: RuleConfig) {
+    this.advisor = new Advisor(ckbCfg, ruleCfg);
+    this.linter = new Linter(ruleCfg);
   }
+
+  /**
+   * Advising charts by data and providing linting results for each chart
+   * @param data
+   * @param fields
+   * @param options
+   * @returns
+   */
+  advise(data: Record<string, any>[], fields?: string[], options?: AdvisorOptions) {
+    const advices = this.advisor.advise(data, fields, options);
+    const advicesAfterLint = advices.map(advice => {
+      const lintResult = this.linter.lint(advice.spec, options);
+      return { ...advice, lint: lintResult};
+    });
+
+    return advicesAfterLint;
+  }
+
+
 }

--- a/packages/chart-advisor/src/interface/index.ts
+++ b/packages/chart-advisor/src/interface/index.ts
@@ -9,3 +9,7 @@ export type DataProperty =
   | (DWAnalyzer.NumberFieldInfo & { name: string; levelOfMeasurements: LOM[] })
   | (DWAnalyzer.DateFieldInfo & { name: string; levelOfMeasurements: LOM[] })
   | (DWAnalyzer.StringFieldInfo & { name: string; levelOfMeasurements: LOM[] });
+
+
+export type DataRow = Record<string, any>;
+export type DataRows = DataRow[];

--- a/packages/chart-advisor/src/linter/get-charttype.ts
+++ b/packages/chart-advisor/src/linter/get-charttype.ts
@@ -1,0 +1,83 @@
+import { AntVSpec, ChartAntVSpec } from '@antv/antv-spec';
+
+const getPointChart = (spec: ChartAntVSpec) => {
+  const specLayer = spec.layer[0];
+  if (specLayer.encoding.size) {
+    return 'bubble_chart';
+  }
+  return 'scatter_plot';
+};
+
+const getArcChart = (spec: ChartAntVSpec) => {
+  const specLayer = spec.layer[0];
+  if (typeof specLayer.mark !== 'string' && specLayer.mark.style && specLayer.mark.style.innerRadius) {
+    return 'donut_chart';
+  }
+  return 'pie_chart';
+};
+
+const getBarChart = (spec: ChartAntVSpec) => {
+  const specLayer = spec.layer[0];
+  if (specLayer.encoding.x.type === 'quantitative' && specLayer.encoding.x.bin) { // histogram
+    return 'histogram';
+  }
+  if (specLayer.encoding.x.type === 'quantitative') { // Bar
+    if (specLayer.encoding.row) return 'grouped_bar_chart';
+    if (specLayer.encoding.x.stack === 'normalize') return 'stacked_bar_chart';
+    if (specLayer.encoding.x.stack || specLayer.encoding.x.stack === 'zero')  return 'percent_stacked_bar_chart';
+    return 'bar_chart';
+  }
+  if (specLayer.encoding.y.type === 'quantitative')  { // Column
+    if (specLayer.encoding.column) return 'grouped_column_chart';
+    if (specLayer.encoding.y.stack === 'normalize') return 'stacked_column_chart';
+    if (specLayer.encoding.y.stack || specLayer.encoding.y.stack === 'zero')  return 'percent_stacked_column_chart';
+    return 'column_chart';
+  }
+  return 'bar_chart';
+};
+
+const getAreaChart = (spec: ChartAntVSpec) => {
+  const specLayer = spec.layer[0];
+  if (specLayer.encoding.color && specLayer.encoding.x.stack === 'normalize') return 'percent_stacked_area_chart';
+  if (specLayer.encoding.color && specLayer.encoding.x.stack) return 'stacked_area_chart';
+  return 'area_chart';
+};
+
+const getLineChart = (spec: ChartAntVSpec) => {
+  const specLayer = spec.layer[0];
+  if (typeof specLayer.mark !== 'string' && specLayer.mark.interpolate) return 'step_line_chart';
+  return 'line_chart';
+};
+
+
+export const getChartType = (spec: AntVSpec) => {
+  let chartType: string;
+  if (spec.basis.type === 'chart') {
+    const chartSpec = spec as ChartAntVSpec;
+    const mark = typeof chartSpec.layer[0].mark === 'string' ? chartSpec.layer[0].mark : chartSpec.layer[0].mark.type;
+    switch (mark) {
+      case 'arc':
+        chartType = getArcChart(chartSpec);
+        break;
+      case 'area':
+        chartType = getAreaChart(chartSpec);
+        break;
+      case 'bar':
+        chartType = getBarChart(chartSpec);
+        break;
+      case 'line':
+        chartType = getLineChart(chartSpec);
+        break;
+      case 'point':
+        chartType = getPointChart(chartSpec);
+        break;
+      case 'rect':
+        chartType = 'heatmap';
+        break;
+      default:
+        chartType = '';
+    }
+  }
+  return chartType;
+};
+

--- a/packages/chart-advisor/src/linter/index.ts
+++ b/packages/chart-advisor/src/linter/index.ts
@@ -1,27 +1,70 @@
-import { RuleConfig } from '../ruler/index';
+import { AntVSpec } from '@antv/antv-spec';
+import { DataFrame } from '@antv/data-wizard';
+import { RuleConfig, processRuleCfg, RuleModule, ChartRuleModule, DesignRuleModule, BasicDataPropertyForAdvice } from '../ruler';
+import { DataRows } from '../interface';
+import { LinterOptions, Lint } from './interface';
+import { getChartType } from './get-charttype';
 
 export class Linter {
-  // TODO: FIX this
-  private ruleCfg: RuleConfig | undefined;
+  private ruleBase: Record<string, RuleModule>;;
 
   constructor(ruleCfg?: RuleConfig) {
-    this.ruleCfg = ruleCfg;
+    this.ruleBase = processRuleCfg(ruleCfg);
   }
 
-  getRuleCfg() {
-    return this.ruleCfg;
+  getRuleBase() {
+    return this.ruleBase;
   }
 
   /**
    *
    * @param spec chart spec written in antv-spec
+   * @param options linting options
    * @returns error[], the issues violated by the chart spec
    */
-  lint(spec: any) {
-    // TODO:
+  lint(spec: AntVSpec, options?: LinterOptions) {
+    // step 0: check spec validation (TODO)
+    let ruleScore: Lint[] = [];
     if (spec) {
-      return [];
+      const chartType = getChartType(spec);
+      if (!chartType) return ruleScore;
+      // step 1: get data in spec and build DataFrame
+      const dataFrame = new DataFrame(spec.data.values as DataRows);
+      const dataProps = dataFrame.info() as BasicDataPropertyForAdvice[];
+      const purpose = options && options.purpose ? options.purpose : undefined;
+      const preferences = options && options.preferences ? options.preferences : undefined;
+
+      // step 2: lint rules
+      // HARD and SOFT rules
+      Object.values(this.ruleBase)
+      .filter(
+        (r: RuleModule) => r.type !== 'DESIGN' && !r.option?.off && r.chartTypes.includes(chartType)
+      )
+      .forEach((r: RuleModule) => {
+        const { type, id, docs } = r;
+
+        // no weight for linter's result
+        const score = (r as ChartRuleModule).validator({dataProps, chartType, purpose, preferences});
+        ruleScore.push({ type, id, score, docs });
+      });
+
+      // DESIGN rules
+      Object.values(this.ruleBase)
+      .filter(
+        (r: RuleModule) => r.type === 'DESIGN' && !r.option?.off && r.chartTypes.includes(chartType)
+      )
+      .forEach((r: RuleModule) => {
+        const { type, id, docs } = r;
+        const fix = (r as DesignRuleModule).optimizer(dataProps, spec);
+        // no fix -> means no violation
+        ruleScore.push({ type, id, score: Object.keys(fix).length === 0 ? 1 : 0, fix, docs });
+      });
     }
-    return [];
+
+    // filter rules without score
+    ruleScore = ruleScore.filter((record: Record<string, any>) => record.score !== 1 );
+    return ruleScore;
   }
 }
+
+export * from './interface';

--- a/packages/chart-advisor/src/linter/interface.ts
+++ b/packages/chart-advisor/src/linter/interface.ts
@@ -1,0 +1,23 @@
+import { Purpose } from '@antv/ckb';
+
+export interface Preferences {
+  canvasLayout: 'landscape' | 'portrait';
+}
+
+export interface LinterOptions {
+  purpose?: Purpose,
+  preferences?: Preferences
+}
+
+export interface Lint {
+  // rule type: hard / soft / design
+  type: string,
+  // ruld id
+  id: string,
+  // rule score
+  score: number,
+  // fix solution
+  fix?: any,
+  // docs
+  docs?: any
+}


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] implement Linter and ChartAdvisor. `advise` in ChartAdvisor means advising with linting. 

⚠️ Due to the compatibility of the current rule design, Linter will trigger wrong lint results as discussed [here](https://yuque.antfin.com/docs/share/03e5bafc-010f-4c8a-863f-63f70a7007fa?#). 
In the next step, the property `trigger` will be added in rules to decide whether the rule is appliable to the given spec.