### PR TITLE
feat(dw): support data conversion by specified data type

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
-      "prettier --write"
+      "prettier --write",
+      "jest --bail --findRelatedTests"
     ]
   },
   "author": {

--- a/packages/auto-chart/package.json
+++ b/packages/auto-chart/package.json
@@ -80,8 +80,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [

--- a/packages/chart-advisor/package.json
+++ b/packages/chart-advisor/package.json
@@ -68,8 +68,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [

--- a/packages/ckb/__tests__/pack.test.ts
+++ b/packages/ckb/__tests__/pack.test.ts
@@ -13,8 +13,8 @@ test('PACK', () => {
 
   const ckb2 = CKBJson(undefined, true);
   const keys2 = Object.keys(ckb2);
-  expect(keys2.length).toBe(52);
-  expect(keys2.includes('nested_pie_chart')).toBe(false);
+  expect(keys2.length).toBe(55);
+  expect(keys2.includes('parallel_coordinates')).toBe(false);
 
   const ckb3 = CKBJson('zh-CN', true);
   const values3 = Object.values(ckb3);

--- a/packages/ckb/package.json
+++ b/packages/ckb/package.json
@@ -54,8 +54,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [

--- a/packages/data-wizard/__tests__/dataset/data-frame.test.ts
+++ b/packages/data-wizard/__tests__/dataset/data-frame.test.ts
@@ -880,3 +880,186 @@ describe('DataFrame data with fillValue', () => {
     data: { type: 'FILL', amount: '100,000 Yuan', date: '2021-08-03' },
   });
 });
+
+describe('DataFrame data with columnTypes', () => {
+  test('1D: basic type', () => {
+    const df = new DataFrame(201, { columnTypes: ['string'] });
+    expect(df.data).toStrictEqual([['201']]);
+    expect(df.colData).toStrictEqual([['201']]);
+  });
+
+  test('1D: basic type with extra indexes and columns', () => {
+    const df = new DataFrame(201, { indexes: ['kk', 'bb'], columns: [5, 6], columnTypes: ['string', 'integer'] });
+    expect(df.data).toStrictEqual([
+      ['201', 201],
+      ['201', 201],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['201', 201],
+      ['201', 201],
+    ]);
+  });
+
+  test('1D: array', () => {
+    const df = new DataFrame([201, '201', 3], { columnTypes: ['string'] });
+    expect(df.data).toStrictEqual([['201'], ['201'], ['3']]);
+    expect(df.colData).toStrictEqual([['201', '201', '3']]);
+  });
+
+  test('1D: array with extra indexes and columns', () => {
+    const df = new DataFrame([1, 2, 201], { indexes: ['b', 'c', 'a'], columns: ['col'], columnTypes: ['string'] });
+    expect(df.data).toStrictEqual([['1'], ['2'], ['201']]);
+    expect(df.colData).toStrictEqual([['1', '2', '201']]);
+  });
+
+  test('1D: object', () => {
+    const df = new DataFrame({ a: 1, b: '201', c: 3 }, { columnTypes: ['string', 'string', 'string'] });
+    expect(df.data).toStrictEqual([['1', '201', '3']]);
+    expect(df.colData).toStrictEqual([['1'], ['201'], ['3']]);
+  });
+
+  test('1D: object with extra indexes and columns', () => {
+    const df = new DataFrame(
+      { a: 1, b: 2, c: 201 },
+      { indexes: ['idx1'], columns: ['c', 'b'], columnTypes: ['', 'string'] }
+    );
+    expect(df.data).toStrictEqual([[201, '2']]);
+    expect(df.colData).toStrictEqual([[201], ['2']]);
+  });
+
+  test('2D: array', () => {
+    const df = new DataFrame(
+      [
+        [1, 4],
+        [2, '201'],
+        [3, 6],
+      ],
+      { columnTypes: ['string', 'integer'] }
+    );
+    expect(df.data).toStrictEqual([
+      ['1', 4],
+      ['2', 201],
+      ['3', 6],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['1', '2', '3'],
+      [4, 201, 6],
+    ]);
+  });
+
+  test('2D: array with extra indexes and columns', () => {
+    const df = new DataFrame(
+      [
+        [1, 4],
+        [2, 5],
+        [3, 6],
+      ],
+      {
+        indexes: ['a', 'b', 'c'],
+        columns: ['col1', 'col2'],
+        columnTypes: ['string', 'integer'],
+      }
+    );
+    expect(df.axes).toStrictEqual([
+      ['a', 'b', 'c'],
+      ['col1', 'col2'],
+    ]);
+    expect(df.data).toStrictEqual([
+      ['1', 4],
+      ['2', 5],
+      ['3', 6],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['1', '2', '3'],
+      [4, 5, 6],
+    ]);
+  });
+
+  test('2D: object array', () => {
+    const df = new DataFrame(
+      [
+        { a: '1', b: '2', c: '3.1', d: 1 },
+        { a: '1', b: '2', d: '4' },
+        { c: '1', d: '2019-02-03', e: 0, f: 201 },
+      ],
+      {
+        columnTypes: ['null', 'boolean', 'float', 'date', 'string'],
+      }
+    );
+    expect(df.data).toStrictEqual([
+      [null, true, 3.1, new Date(1), 'undefined', undefined],
+      [null, true, NaN, new Date('4'), 'undefined', undefined],
+      [undefined, false, 1, '2019-02-03', '0', 201],
+    ]);
+    expect(df.colData).toStrictEqual([
+      [null, null, undefined],
+      [true, true, false],
+      [3.1, NaN, 1],
+      [new Date(1), new Date('4'), '2019-02-03'],
+      ['undefined', 'undefined', '0'],
+      [undefined, undefined, 201],
+    ]);
+  });
+
+  test('2D: object array with extra indexes and columns', () => {
+    const df = new DataFrame(
+      [
+        { a: 1, b: 4, c: 7 },
+        { a: 2, b: 5, c: 201 },
+        { a: 3, b: 201, c: 9 },
+      ],
+      { indexes: ['k', 'm', 'n'], columns: ['c', 'a'], columnTypes: ['string', ''] }
+    );
+    expect(df.data).toStrictEqual([
+      ['7', 1],
+      ['201', 2],
+      ['9', 3],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['7', '201', '9'],
+      [1, 2, 3],
+    ]);
+  });
+
+  test('2D: array object', () => {
+    const df = new DataFrame(
+      {
+        a: [1, 2, null],
+        b: [4, undefined, 6],
+      },
+      { columnTypes: ['string', 'integer'] }
+    );
+    expect(df.data).toStrictEqual([
+      ['1', 4],
+      ['2', NaN],
+      ['null', 6],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['1', '2', 'null'],
+      [4, NaN, 6],
+    ]);
+  });
+
+  test('2D: array object with extra indexes and columns', () => {
+    const df = new DataFrame(
+      {
+        a: [1, 2, 201],
+        b: ['201', 5, 6],
+      },
+      {
+        indexes: ['p', 'q', 'r'],
+        columns: ['b', 'a'],
+        columnTypes: ['string', 'integer'],
+      }
+    );
+    expect(df.data).toStrictEqual([
+      ['201', 1],
+      ['5', 2],
+      ['6', 201],
+    ]);
+    expect(df.colData).toStrictEqual([
+      ['201', '5', '6'],
+      [1, 2, 201],
+    ]);
+  });
+});

--- a/packages/data-wizard/__tests__/dataset/data-frame.test.ts
+++ b/packages/data-wizard/__tests__/dataset/data-frame.test.ts
@@ -28,7 +28,7 @@ describe('new DataFrame', () => {
 
   test('1D: basic type with error extra', () => {
     expect(() => new DataFrame(1, { columns: [5, 6] })).toThrow(
-      'When the length of extra?.columns is larger than 1, extra?.indexes is required.'
+      'When the length of extra.columns is larger than 1, extra.indexes is required.'
     );
   });
 

--- a/packages/data-wizard/__tests__/dataset/series.test.ts
+++ b/packages/data-wizard/__tests__/dataset/series.test.ts
@@ -140,3 +140,36 @@ describe('Series data with fillValue', () => {
     expect(s.data).toStrictEqual([201, 2, 3]);
   });
 });
+
+describe('Series data with columnTypes', () => {
+  test('1D: basic type', () => {
+    const s = new Series(201, { columnTypes: ['string'] });
+    expect(s.data).toStrictEqual(['201']);
+  });
+
+  test('1D: basic type with extra indexes', () => {
+    const s = new Series(201, { indexes: [0, 1, 2], columnTypes: ['string'] });
+    expect(s.data).toStrictEqual(['201', '201', '201']);
+  });
+
+  test('1D: object', () => {
+    const s = new Series({ a: 1, b: 201, c: 3 }, { columnTypes: ['string'] });
+    expect(s.data).toStrictEqual(['1', '201', '3']);
+  });
+
+  test('1D: object with extra indexes', () => {
+    const s = new Series({ a: 1, b: 2, c: '201' }, { indexes: ['c', 'a'], columnTypes: ['string'] });
+    expect(s.data).toStrictEqual(['201', '1']);
+  });
+
+  test('1D: array', () => {
+    const s = new Series([201, 2, '201'], { columnTypes: ['string'] });
+    expect(s.data).toStrictEqual(['201', '2', '201']);
+  });
+
+  test('1D: array with extra indexes', () => {
+    const s = new Series([201, 2, 3], { indexes: ['a', 'b', 'c'], columnTypes: ['string'] });
+    expect(s.axes).toStrictEqual([['a', 'b', 'c']]);
+    expect(s.data).toStrictEqual(['201', '2', '3']);
+  });
+});

--- a/packages/data-wizard/package.json
+++ b/packages/data-wizard/package.json
@@ -44,8 +44,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [

--- a/packages/data-wizard/src/dataset/base-frame.ts
+++ b/packages/data-wizard/src/dataset/base-frame.ts
@@ -1,5 +1,5 @@
 import { assert, isArray, isObject, isBasicType } from '../utils';
-import { generateArrayIndex, fillMissingValue, convertDatumType } from './utils';
+import { generateArrayIndex, fillMissingValue, convertDataType } from './utils';
 import type { SeriesData, FrameData, Axis, Extra } from './types';
 
 type NDArray = any[] | any[][];
@@ -21,10 +21,10 @@ export default abstract class BaseFrame {
       if (extra?.indexes) {
         this.setAxis(0, extra?.indexes);
         this.data = Array(extra?.indexes.length).fill(
-          convertDatumType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])
+          convertDataType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])
         );
       } else {
-        this.data = [convertDatumType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])];
+        this.data = [convertDataType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])];
         this.setAxis(0, [0]);
       }
     } else if (isArray(data)) {
@@ -54,7 +54,7 @@ export default abstract class BaseFrame {
         this.data = extra?.fillValue ? data.map((datum) => fillMissingValue(datum, extra?.fillValue)) : data;
         if (extra?.columnTypes?.length) {
           for (let i = 0; i < this.data.length; i += 1) {
-            this.data[i] = convertDatumType(this.data[i], extra?.columnTypes?.[0]);
+            this.data[i] = convertDataType(this.data[i], extra?.columnTypes?.[0]);
           }
         }
       }

--- a/packages/data-wizard/src/dataset/base-frame.ts
+++ b/packages/data-wizard/src/dataset/base-frame.ts
@@ -1,5 +1,5 @@
 import { assert, isArray, isObject, isBasicType } from '../utils';
-import { generateArrayIndex, fillMissingValue } from './utils';
+import { generateArrayIndex, fillMissingValue, convertDatumType } from './utils';
 import type { SeriesData, FrameData, Axis, Extra } from './types';
 
 type NDArray = any[] | any[][];
@@ -20,9 +20,11 @@ export default abstract class BaseFrame {
       // generate indexes
       if (extra?.indexes) {
         this.setAxis(0, extra?.indexes);
-        this.data = Array(extra?.indexes.length).fill(fillMissingValue(data, extra?.fillValue));
+        this.data = Array(extra?.indexes.length).fill(
+          convertDatumType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])
+        );
       } else {
-        this.data = [fillMissingValue(data, extra?.fillValue)];
+        this.data = [convertDatumType(fillMissingValue(data, extra?.fillValue), extra?.columnTypes?.[0])];
         this.setAxis(0, [0]);
       }
     } else if (isArray(data)) {
@@ -50,6 +52,11 @@ export default abstract class BaseFrame {
           this.setAxis(0, extra?.indexes);
         }
         this.data = extra?.fillValue ? data.map((datum) => fillMissingValue(datum, extra?.fillValue)) : data;
+        if (extra?.columnTypes?.length) {
+          for (let i = 0; i < this.data.length; i += 1) {
+            this.data[i] = convertDatumType(this.data[i], extra?.columnTypes?.[0]);
+          }
+        }
       }
     }
   }

--- a/packages/data-wizard/src/dataset/series.ts
+++ b/packages/data-wizard/src/dataset/series.ts
@@ -1,12 +1,9 @@
 import { isObject, isNumber, isString, isInteger, isBasicType, isArray, range, assert } from '../utils';
-import { fillMissingValue } from './utils';
+import { fillMissingValue, convertDatumType } from './utils';
 import BaseFrame from './base-frame';
 import type { SeriesData, Extra, Axis } from './types';
 
-export interface SeriesExtra {
-  indexes?: Extra['indexes'];
-  fillValue?: Extra['fillValue'];
-}
+export type SeriesExtra = Pick<Extra, 'indexes' | 'fillValue' | 'columnTypes'>;
 
 /** 1D data structure */
 export default class Series extends BaseFrame {
@@ -29,12 +26,14 @@ export default class Series extends BaseFrame {
         for (let i = 0; i < extra?.indexes.length; i += 1) {
           const idx = extra?.indexes[i] as string;
           if (indexes.includes(idx)) {
-            this.data.push(fillMissingValue(data[idx], extra?.fillValue));
+            this.data.push(convertDatumType(fillMissingValue(data[idx], extra?.fillValue), extra?.columnTypes?.[0]));
           }
         }
         this.setAxis(0, extra?.indexes);
       } else {
-        this.data = Object.values(data).map((datum) => fillMissingValue(datum, extra?.fillValue));
+        this.data = Object.values(data).map((datum) =>
+          convertDatumType(fillMissingValue(datum, extra?.fillValue), extra?.columnTypes?.[0])
+        );
         this.setAxis(0, indexes);
       }
     } else if (isArray(data)) {

--- a/packages/data-wizard/src/dataset/series.ts
+++ b/packages/data-wizard/src/dataset/series.ts
@@ -1,5 +1,5 @@
 import { isObject, isNumber, isString, isInteger, isBasicType, isArray, range, assert } from '../utils';
-import { fillMissingValue, convertDatumType } from './utils';
+import { fillMissingValue, convertDataType } from './utils';
 import BaseFrame from './base-frame';
 import type { SeriesData, Extra, Axis } from './types';
 
@@ -26,13 +26,13 @@ export default class Series extends BaseFrame {
         for (let i = 0; i < extra?.indexes.length; i += 1) {
           const idx = extra?.indexes[i] as string;
           if (indexes.includes(idx)) {
-            this.data.push(convertDatumType(fillMissingValue(data[idx], extra?.fillValue), extra?.columnTypes?.[0]));
+            this.data.push(convertDataType(fillMissingValue(data[idx], extra?.fillValue), extra?.columnTypes?.[0]));
           }
         }
         this.setAxis(0, extra?.indexes);
       } else {
         this.data = Object.values(data).map((datum) =>
-          convertDatumType(fillMissingValue(datum, extra?.fillValue), extra?.columnTypes?.[0])
+          convertDataType(fillMissingValue(datum, extra?.fillValue), extra?.columnTypes?.[0])
         );
         this.setAxis(0, indexes);
       }

--- a/packages/data-wizard/src/dataset/types.ts
+++ b/packages/data-wizard/src/dataset/types.ts
@@ -1,4 +1,4 @@
-import type { StringFieldInfo, NumberFieldInfo, DateFieldInfo } from '../analyzer';
+import type { StringFieldInfo, NumberFieldInfo, DateFieldInfo, TypeSpecifics } from '../analyzer';
 
 export type SeriesData =
   /**
@@ -93,6 +93,7 @@ export type Extra = {
   indexes?: Axis[];
   columns?: Axis[];
   fillValue?: any;
+  columnTypes?: TypeSpecifics[];
 };
 
 /**

--- a/packages/data-wizard/src/dataset/types.ts
+++ b/packages/data-wizard/src/dataset/types.ts
@@ -93,7 +93,8 @@ export type Extra = {
   indexes?: Axis[];
   columns?: Axis[];
   fillValue?: any;
-  columnTypes?: TypeSpecifics[];
+  /** When the columnType is empty, no data type is specified */
+  columnTypes?: (TypeSpecifics | '')[];
 };
 
 /**

--- a/packages/data-wizard/src/dataset/utils.ts
+++ b/packages/data-wizard/src/dataset/utils.ts
@@ -1,7 +1,6 @@
 import { isDateString } from '../analyzer/is-date';
 import { isArray, isNumber, isString, range, assert, isBoolean, isNull } from '../utils';
-import type { TypeSpecifics } from '../analyzer';
-import type { Axis } from './types';
+import type { Axis, Extra } from './types';
 
 export const isAxis = (value: any): value is Axis => {
   return isNumber(value) || isString(value);
@@ -65,30 +64,30 @@ export const stringify = (value: any) =>
 export const getStringifyLength = (value: any) => stringify(value)?.length;
 
 /**
- * Convert datum to specified data type.
+ * Convert data to specified data type.
  * @param datum
  * @param type
- * @returns converted datum
+ * @returns converted data
  */
-export const convertDatumType = (datum: any, type: TypeSpecifics) => {
+export const convertDataType = (data: any, type: Extra['columnTypes'][number]) => {
   try {
-    if (type === 'string' && !isString(datum)) {
-      return `${datum}`;
+    if (type === 'string' && !isString(data)) {
+      return `${data}`;
     }
-    if (type === 'boolean' && !isBoolean(datum)) {
-      return Boolean(datum);
+    if (type === 'boolean' && !isBoolean(data)) {
+      return Boolean(data);
     }
-    if (type === 'null' && !isNull(datum)) {
+    if (type === 'null' && !isNull(data)) {
       return null;
     }
-    if ((type === 'integer' || type === 'float') && !isNumber(datum)) {
-      return +datum;
+    if ((type === 'integer' || type === 'float') && !isNumber(data)) {
+      return +data;
     }
-    if (type === 'date' && !isDateString(`${datum}`)) {
-      return new Date(datum);
+    if (type === 'date' && !isDateString(`${data}`)) {
+      return new Date(data);
     }
   } catch (error) {
     throw new Error(error);
   }
-  return datum;
+  return data;
 };

--- a/packages/data-wizard/src/dataset/utils.ts
+++ b/packages/data-wizard/src/dataset/utils.ts
@@ -1,4 +1,6 @@
-import { isArray, isNumber, isString, range, assert } from '../utils';
+import { isDateString } from '../analyzer/is-date';
+import { isArray, isNumber, isString, range, assert, isBoolean, isNull } from '../utils';
+import type { TypeSpecifics } from '../analyzer';
 import type { Axis } from './types';
 
 export const isAxis = (value: any): value is Axis => {
@@ -61,3 +63,32 @@ export const stringify = (value: any) =>
     ?.replace(/\}"/g, ' }') || 'undefined';
 
 export const getStringifyLength = (value: any) => stringify(value)?.length;
+
+/**
+ * Convert datum to specified data type.
+ * @param datum
+ * @param type
+ * @returns converted datum
+ */
+export const convertDatumType = (datum: any, type: TypeSpecifics) => {
+  try {
+    if (type === 'string' && !isString(datum)) {
+      return `${datum}`;
+    }
+    if (type === 'boolean' && !isBoolean(datum)) {
+      return Boolean(datum);
+    }
+    if (type === 'null' && !isNull(datum)) {
+      return null;
+    }
+    if ((type === 'integer' || type === 'float') && !isNumber(datum)) {
+      return +datum;
+    }
+    if (type === 'date' && !isDateString(`${datum}`)) {
+      return new Date(datum);
+    }
+  } catch (error) {
+    throw new Error(error);
+  }
+  return datum;
+};

--- a/packages/lite-insight/package.json
+++ b/packages/lite-insight/package.json
@@ -44,8 +44,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [

--- a/packages/smart-board/package.json
+++ b/packages/smart-board/package.json
@@ -75,8 +75,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "limit-size": [


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
Support data conversion by specified data type, and add related test cases. Resolved #381.

Use the `extra.columnTypes` to convert the original data, and its value could be anyone of `TypeSpecifics ('null' | 'boolean' | 'integer' | 'float' | 'date' | 'string')`. The `extra.columnTypes` is an array mapped to `columns`. If you need original data type, the column type could be specified as `''`.

In addition, the issue fixes CKB's `pack.test.ts` and adds jest in pre-commit.