### PR TITLE
chore(SB): fix peer dep

### DIFF
--- a/packages/smart-board/package.json
+++ b/packages/smart-board/package.json
@@ -44,6 +44,10 @@
     "url": "https://github.com/antvis/SmartBoard/issues"
   },
   "homepage": "https://github.com/antvis/SmartBoard#readme",
+  "peerDependencies": {
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
+  },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@types/jest": "^23.3.12",
@@ -55,6 +59,8 @@
     "lint-staged": "^11.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",
     "typescript": "4.3.5"
@@ -68,7 +74,6 @@
     "@antv/lite-insight": "^2.0.0",
     "antd": "^4.16.13",
     "louvain-algorithm": "^1.0.4",
-    "react": "^17.0.2",
     "tslib": "^2.2.0",
     "uuid": "^3.4.0"
   },


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

fix:

```bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @antv/smart-board@2.0.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR!   peer react@">=16.0.0" from @ant-design/icons@4.7.0
npm ERR!   node_modules/@ant-design/icons
npm ERR!     @ant-design/icons@"^4.7.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^18.0.0" from react-dom@18.0.0
npm ERR! node_modules/react-dom
npm ERR!   peer react-dom@">=16.0.0" from @ant-design/icons@4.7.0
npm ERR!   node_modules/@ant-design/icons
npm ERR!     @ant-design/icons@"^4.7.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```