### PR TITLE
feat(dw): create a unique seed to avoid duplicate timestamps causing random data

### DIFF
--- a/packages/data-wizard/__tests__/random/case.test.ts
+++ b/packages/data-wizard/__tests__/random/case.test.ts
@@ -1,0 +1,33 @@
+import { BasicRandom, TextRandom, AddressRandom } from '../../src/random';
+
+describe('Case test', () => {
+  test('Generate object array', () => {
+    const NUM = 10000;
+    const results = [];
+    for (let i = 0; i < NUM; i += 1) {
+      results.push({
+        name: new TextRandom().givenName(),
+        age: new BasicRandom().integer({ min: 18, max: 36 }),
+        salary: new BasicRandom().integer({ min: 5000, max: 36000 }),
+        city: new AddressRandom().city(),
+      });
+    }
+
+    expect(results.length).toBe(NUM);
+  });
+
+  test('Generate object array with unique object', () => {
+    const NUM = 1000;
+    const results = [];
+    for (let i = 0; i < NUM; i += 1) {
+      const result = {
+        name: new TextRandom().givenName(),
+        age: new BasicRandom().integer({ min: 18, max: 36 }),
+        salary: new BasicRandom().integer({ min: 5000, max: 36000 }),
+        city: new AddressRandom().city(),
+      };
+      expect(results).not.toContainEqual(result);
+      results.push(result);
+    }
+  });
+});

--- a/packages/data-wizard/src/analyzer/is-date.ts
+++ b/packages/data-wizard/src/analyzer/is-date.ts
@@ -40,17 +40,17 @@ export const getIsoTimes = (isStrict = true) => [
   `${hour}:${isStrict ? '' : '?'}${minute}?${offset}`,
 ];
 
-const isoDatats = getIsoDates();
+const isoDates = getIsoDates();
 const isoTimes = getIsoTimes();
-const formatstr = [...isoDatats, ...isoTimes];
+const formatStr = [...isoDates, ...isoTimes];
 
-isoDatats.forEach((d) => {
+isoDates.forEach((d) => {
   isoTimes.forEach((t) => {
-    formatstr.push(`${d}[T\\s]${t}`);
+    formatStr.push(`${d}[T\\s]${t}`);
   });
 });
 
-const formats: RegExp[] = formatstr.map((item) => {
+const formats: RegExp[] = formatStr.map((item) => {
   return new RegExp(`^${item}$`);
 });
 

--- a/packages/data-wizard/src/random/basic-random.ts
+++ b/packages/data-wizard/src/random/basic-random.ts
@@ -65,8 +65,9 @@ export class BasicRandom {
     if (isFunction(seed)) {
       this.random = seed;
     } else {
-      // If no generator function was provided, use our MT
-      this.seed = seed;
+      // If no generator function was provided, use MT
+      // If seed is undefined, create a random number as seed to avoid the case that timestamps are the same.
+      this.seed = seed || new Date().getTime() + +`${Math.random()}`.slice(2);
       this.mt = new MersenneTwister(this.seed);
       this.random = this.mt.random.bind(this.mt);
     }


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
If seed is undefined, the package [`mersenne-twister` uses `new Date().getTime()` as seed](https://github.com/boo1ean/mersenne-twister/blob/master/src/mersenne-twister.js#L69). However, the timestamps may be the same, such as [generating random data in a loop](https://github.com/antvis/AVA/pull/403/files#diff-ea92f661b76daa59687874b3ae571db17c4d99b01e038d880562e746c0f47304R5-R14).

<img width="833" alt="4182BA7F-D305-4895-A648-DFF53118EDF4" src="https://user-images.githubusercontent.com/15177000/162350240-235e8373-65ae-4cc4-8408-2ff3c671224e.png">

The PR [create a random number as seed](https://github.com/antvis/AVA/pull/403/files#diff-ba90428a529645ccc799ea4ce08071d7ca645d7c6027bf13fbb68139e4480535R70) when the seed is undefined to avoid the case that timestamps are the same.