### PR TITLE
docs: fix readme path

### DIFF
--- a/packages/auto-chart/README.md
+++ b/packages/auto-chart/README.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./README.zh-CN.md)
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./zh-CN/README.zh-CN.md)
 
 <h1 align="center">
   <p>AutoChart</p>

--- a/packages/auto-chart/zh-CN/README.zh-CN.md
+++ b/packages/auto-chart/zh-CN/README.zh-CN.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](./README.md) | 简体中文
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](../README.md) | 简体中文
 
 <h1 align="center">
   <p>AutoChart</p>

--- a/packages/chart-advisor/README.md
+++ b/packages/chart-advisor/README.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./README.zh-CN.md)
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./zh-CN/README.zh-CN.md)
 
 <h1 align="center">
   <p>ChartAdvisor</p>

--- a/packages/chart-advisor/zh-CN/README.zh-CN.md
+++ b/packages/chart-advisor/zh-CN/README.zh-CN.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](./README.md) | 简体中文
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](../README.md) | 简体中文
 
 <h1 align="center">
   <p>ChartAdvisor</p>

--- a/packages/data-wizard/README.md
+++ b/packages/data-wizard/README.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./README.zh-CN.md)
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./zh-CN/README.zh-CN.md)
 
 
 <h1 align="center">

--- a/packages/data-wizard/zh-CN/README.zh-CN.md
+++ b/packages/data-wizard/zh-CN/README.zh-CN.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](./README.md) | 简体中文
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](../README.md) | 简体中文
 
 
 <h1 align="center">

--- a/packages/lite-insight/README.md
+++ b/packages/lite-insight/README.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./README.zh-CN.md)
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./zh-CN/README.zh-CN.md)
 
 
 <h1 align="center">

--- a/packages/lite-insight/zh-CN/README.zh-CN.md
+++ b/packages/lite-insight/zh-CN/README.zh-CN.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](./README.md) | 简体中文
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](../README.md) | 简体中文
 
 
 <h1 align="center">

--- a/packages/smart-board/README.md
+++ b/packages/smart-board/README.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./README.zh-CN.md)
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> English | [简体中文](./zh-CN/README.zh-CN.md)
 
 
 <h1 align="center">

--- a/packages/smart-board/zh-CN/README.zh-CN.md
+++ b/packages/smart-board/zh-CN/README.zh-CN.md
@@ -1,4 +1,4 @@
-<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](./README.md) | 简体中文
+<img src="https://gw.alipayobjects.com/zos/antfincdn/R8sN%24GNdh6/language.svg" width="18"> [English](../README.md) | 简体中文
 
 
 <h1 align="center">


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [x] documents, demos

Fix the Chinese and English README.md file paths of AutoChart, ChartAdvisor, DataWizard, LiteInsight and SmartBoard.
