### PR TITLE
fix: correct api reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It can automatically generates the corresponding Dashboard configurations based 
 ## Sources
 
 * [Guide](https://ava.antv.vision/en/docs/guide/intro)
-* [API](https://ava.antv.vision/en/docs/api/intro)
+* [API](https://ava.antv.vision/en/docs/api)
 * [Examples](https://ava.antv.vision/en/examples/gallery)
 * [Wiki](https://github.com/antvis/AVA/wiki)
 

--- a/packages/auto-chart/README.md
+++ b/packages/auto-chart/README.md
@@ -52,7 +52,7 @@ ReactDOM.render(<AutoChart data={data} />, document.getElementById('container'))
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/auto-chart/autoChart)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/auto-chart/AutoChart)
 
 ## Contribution
 

--- a/packages/auto-chart/zh-CN/README.zh-CN.md
+++ b/packages/auto-chart/zh-CN/README.zh-CN.md
@@ -51,7 +51,7 @@ ReactDOM.render(<AutoChart data={data} />, document.getElementById('container'))
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/auto-chart/autoChart)
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/auto-chart/AutoChart)
 
 
 ## 贡献

--- a/packages/chart-advisor/README.md
+++ b/packages/chart-advisor/README.md
@@ -166,7 +166,7 @@ const problems = myLinter.lint({ spec })
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/chart-advisor/intro)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/chart-advisor/ChartAdvisor)
 
 ## Contribution
 

--- a/packages/chart-advisor/zh-CN/README.zh-CN.md
+++ b/packages/chart-advisor/zh-CN/README.zh-CN.md
@@ -157,7 +157,7 @@ const problems = myLinter.lint({ spec })
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/chart-advisor/intro)
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/chart-advisor/ChartAdvisor)
 
 
 ## 贡献

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -81,6 +81,9 @@ const zhCompletedKB = CKBJson('zh-CN', true);
 ## Documentation
 
 * For more usages, please check the [Quick API](./API.md)
+```js
+// ../../docs/api/knowledge.md does not exist
+```
 * Detailed [API Reference](../../docs/api/knowledge.md)
 * [User Guide](./USERGUIDE.md)
 

--- a/packages/smart-board/README.md
+++ b/packages/smart-board/README.md
@@ -81,7 +81,7 @@ const dashboardContent =
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/smart-board/intro)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/smart-board/SmartBoard)
 
 
 ## 📄 License

--- a/packages/smart-board/zh-CN/README.zh-CN.md
+++ b/packages/smart-board/zh-CN/README.zh-CN.md
@@ -81,7 +81,7 @@ const dashboardContent =
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/smart-board/intro)
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/smart-board/SmartBoard)
 
 
 

--- a/sites/ava-site/docs/guide/auto-chart/intro.en.md
+++ b/sites/ava-site/docs/guide/auto-chart/intro.en.md
@@ -56,4 +56,4 @@ ReactDOM.render(
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/auto-chart/intro)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/auto-chart/AutoChart)

--- a/sites/ava-site/docs/guide/auto-chart/intro.zh.md
+++ b/sites/ava-site/docs/guide/auto-chart/intro.zh.md
@@ -55,4 +55,4 @@ ReactDOM.render(
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/auto-chart/intro)
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/auto-chart/AutoChart)

--- a/sites/ava-site/docs/guide/chart-advisor/intro.en.md
+++ b/sites/ava-site/docs/guide/chart-advisor/intro.en.md
@@ -163,7 +163,7 @@ const problems = myLinter.lint({ spec })
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/chart-advisor/intro)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/chart-advisor/ChartAdvisor)
 
 
 

--- a/sites/ava-site/docs/guide/chart-advisor/intro.zh.md
+++ b/sites/ava-site/docs/guide/chart-advisor/intro.zh.md
@@ -154,7 +154,7 @@ const problems = myLinter.lint({ spec })
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/chart-advisor/intro)
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/chart-advisor/ChartAdvisor)
 
 
 

--- a/sites/ava-site/docs/guide/smart-board/intro.en.md
+++ b/sites/ava-site/docs/guide/smart-board/intro.en.md
@@ -130,7 +130,7 @@ ReactDOM.render(
 
 ## 📖 Documentation
 
-For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/smart-board/intro)
+For more usages, please check the [API Reference](https://ava.antv.vision/en/docs/api/smart-board/SmartBoard)
 
 
 

--- a/sites/ava-site/docs/guide/smart-board/intro.zh.md
+++ b/sites/ava-site/docs/guide/smart-board/intro.zh.md
@@ -131,7 +131,4 @@ ReactDOM.render(
 
 ## 📖 文档
 
-更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/smart-board/intro)
-
-
-
+更多用法请移步至 [官网API](https://ava.antv.vision/zh/docs/api/smart-board/SmartBoard)

--- a/sites/ava-site/examples/chart-advisor/advise-and-lint/API.en.md
+++ b/sites/ava-site/examples/chart-advisor/advise-and-lint/API.en.md
@@ -1,6 +1,6 @@
 # ChartAdvisor
 
-`markdown:docs/api/chart-advisor/intro.en.md`
+`markdown:docs/api/chart-advisor/0_ChartAdvisor.en.md`
 
 # ChartAdvisor.advise
 

--- a/sites/ava-site/examples/chart-advisor/advise-and-lint/API.zh.md
+++ b/sites/ava-site/examples/chart-advisor/advise-and-lint/API.zh.md
@@ -1,6 +1,6 @@
 # ChartAdvisor
 
-`markdown:docs/api/chart-advisor/intro.zh.md`
+`markdown:docs/api/chart-advisor/0_ChartAdvisor.zh.md`
 
 # ChartAdvisor.advise
 

--- a/sites/ava-site/examples/components/auto-chart/API.en.md
+++ b/sites/ava-site/examples/components/auto-chart/API.en.md
@@ -1,3 +1,3 @@
 # AutoChart
 
-`markdown:docs/api/auto-chart/intro.en.md`
+`markdown:docs/api/auto-chart/AutoChart.en.md`

--- a/sites/ava-site/examples/components/auto-chart/API.zh.md
+++ b/sites/ava-site/examples/components/auto-chart/API.zh.md
@@ -1,3 +1,3 @@
 # AutoChart
 
-`markdown:docs/api/auto-chart/intro.zh.md`
+`markdown:docs/api/auto-chart/AutoChart.zh.md`

--- a/sites/ava-site/examples/smart-board/basic/API.en.md
+++ b/sites/ava-site/examples/smart-board/basic/API.en.md
@@ -1,3 +1,3 @@
 # SmartBoard
 
-`markdown:docs/api/smart-board/intro.en.md`
+`markdown:docs/api/smart-board/SmartBoard.en.md`

--- a/sites/ava-site/examples/smart-board/basic/API.zh.md
+++ b/sites/ava-site/examples/smart-board/basic/API.zh.md
@@ -1,3 +1,3 @@
 # SmartBoard
 
-`markdown:docs/api/smart-board/intro.zh.md`
+`markdown:docs/api/smart-board/SmartBoard.zh.md`


### PR DESCRIPTION
Correct invalid api reference links, including:

- links in guides
- links in examples
- others