### PR TITLE
refactor(chart-advisor): change validator and trigger api

### DIFF
--- a/packages/chart-advisor/__tests__/rule.test.ts
+++ b/packages/chart-advisor/__tests__/rule.test.ts
@@ -1,5 +1,13 @@
 import { Advisor } from '../src/advisor';
-import { builtInRules, RuleConfig, RuleModule, getChartRule } from '../src/ruler';
+import {
+  builtInRules,
+  RuleConfig,
+  RuleModule,
+  getChartRule,
+  ChartRuleModule,
+  CustomTrigger,
+  CustomValidator,
+} from '../src/ruler';
 
 const myRule: RuleModule = {
   id: 'fufu-rule',
@@ -35,17 +43,27 @@ const ruleWithExtra: RuleModule = {
       level: 99,
     },
   },
-  trigger: (args) => {
-    const { chartType, weight } = args;
-    return ['pie_chart'].indexOf(chartType) !== -1 && weight > 0;
+  trigger: {
+    func: (args) => {
+      const { chartType, weight } = args;
+      return ['pie_chart'].indexOf(chartType) !== -1 && weight > 0;
+    },
+    customArgs: {
+      level: 99,
+    },
   },
-  validator: (args) => {
-    let result = 0;
-    const { name, level } = args;
-    if (name === 'ShuShu' && level > 50) {
-      result = 1;
-    }
-    return result;
+  validator: {
+    func: (args) => {
+      let result = 0;
+      const { name, level } = args;
+      if (name === 'ShuShu' && level > 50) {
+        result = 1;
+      }
+      return result;
+    },
+    customArgs: {
+      name: 'ShuShu',
+    },
   },
 };
 
@@ -162,6 +180,10 @@ describe('customized Rule', () => {
     };
     const myAdvisor = new Advisor({ ruleCfg: myRuleCfg });
     const { ruleBase } = myAdvisor;
-    expect(ruleBase['shushu-rule'].option?.extra).toHaveProperty(['name'], 'ShuShu');
+    expect((ruleBase['shushu-rule'].trigger as CustomTrigger).customArgs).toHaveProperty(['level'], 99);
+    expect(((ruleBase['shushu-rule'] as ChartRuleModule).validator as CustomValidator).customArgs).toHaveProperty(
+      ['name'],
+      'ShuShu'
+    );
   });
 });

--- a/packages/chart-advisor/src/advisor/advice-pipeline/data-to-advices.ts
+++ b/packages/chart-advisor/src/advisor/advice-pipeline/data-to-advices.ts
@@ -1,6 +1,7 @@
 import { hexToColor, colorToHex, paletteGeneration, colorSimulation } from '@antv/smart-color';
 
 import { deepMix, computeScore } from '../utils';
+import { isCustomTrigger } from '../../ruler/utils';
 
 import { getChartTypeSpec } from './spec-mapping';
 
@@ -84,10 +85,12 @@ function applyDesignRules(
   ruleBase: Record<string, RuleModule>,
   chartSpec: Specification
 ) {
-  const toCheckRules = Object.values(ruleBase).filter(
-    (rule: RuleModule) =>
-      rule.type === 'DESIGN' && rule.trigger({ dataProps, chartType }) && !ruleBase[rule.id].option?.off
-  );
+  const toCheckRules = Object.values(ruleBase).filter((rule: RuleModule) => {
+    if (isCustomTrigger(rule.trigger)) {
+      return rule.type === 'DESIGN' && rule.trigger.func({ dataProps, chartType }) && !rule.option?.off;
+    }
+    return rule.type === 'DESIGN' && rule.trigger({ dataProps, chartType }) && !rule.option?.off;
+  });
   const encodingSpec = toCheckRules.reduce((lastSpec, rule: RuleModule) => {
     const relatedSpec = (rule as DesignRuleModule).optimizer(dataProps, chartSpec);
     return deepMix(lastSpec, relatedSpec);

--- a/packages/chart-advisor/src/advisor/utils/computeScore.ts
+++ b/packages/chart-advisor/src/advisor/utils/computeScore.ts
@@ -19,7 +19,7 @@ const computeScore = (
     .filter((r: ChartRuleModule) => {
       const weight = r.option?.weight || defaultWeights[r.id] || 1;
       if (isCustomTrigger(r.trigger)) {
-        const { customArgs } = r.trigger.customArgs;
+        const { customArgs } = r.trigger;
         return r.type === ruleType && r.trigger.func({ ...info, weight, ...customArgs }) && !r.option?.off;
       }
       return r.type === ruleType && r.trigger({ ...info, weight }) && !r.option?.off;
@@ -28,7 +28,7 @@ const computeScore = (
       const weight = r.option?.weight || defaultWeights[r.id] || 1;
       let base: number;
       if (isCustomValidator(r.validator)) {
-        const { customArgs } = r.validator.customArgs;
+        const { customArgs } = r.validator;
         base = r.validator.func({
           ...info,
           weight,

--- a/packages/chart-advisor/src/linter/utils/lintRules.ts
+++ b/packages/chart-advisor/src/linter/utils/lintRules.ts
@@ -23,7 +23,7 @@ const lintRules = (
     .filter((r: RuleModule) => {
       const { weight } = r.option || {};
       if (isCustomTrigger(r.trigger)) {
-        const { customArgs } = r.trigger.customArgs;
+        const { customArgs } = r.trigger;
         return judge(r.type) && !r.option?.off && r.trigger.func({ ...info, weight, ...customArgs });
       }
       return judge(r.type) && !r.option?.off && r.trigger({ ...info, weight });
@@ -41,7 +41,7 @@ const lintRules = (
         // no weight for linter's result
         let score: number;
         if (isCustomValidator(r.validator)) {
-          const { customArgs } = r.validator.customArgs;
+          const { customArgs } = r.validator;
           r.validator.func({
             ...info,
             weight,

--- a/packages/chart-advisor/src/linter/utils/lintRules.ts
+++ b/packages/chart-advisor/src/linter/utils/lintRules.ts
@@ -1,8 +1,8 @@
 import { Info, RuleModule } from '../../ruler';
+import { isCustomTrigger, isCustomValidator, isDesignRuleModule } from '../../ruler/utils';
 
 import type { Specification, Lint } from '../../types';
 import type { ScoringResultForRule } from '../../advisor';
-import type { ChartRuleModule, DesignRuleModule } from '../../ruler/interface';
 
 const lintRules = (
   ruleBase: Record<string, RuleModule>,
@@ -21,21 +21,35 @@ const lintRules = (
 
   Object.values(ruleBase)
     .filter((r: RuleModule) => {
-      const { weight, extra } = r.option || {};
-      return judge(r.type) && !r.option?.off && r.trigger({ ...info, weight, ...extra });
+      const { weight } = r.option || {};
+      if (isCustomTrigger(r.trigger)) {
+        const { customArgs } = r.trigger.customArgs;
+        return judge(r.type) && !r.option?.off && r.trigger.func({ ...info, weight, ...customArgs });
+      }
+      return judge(r.type) && !r.option?.off && r.trigger({ ...info, weight });
     })
     .forEach((r: RuleModule) => {
       const { type, id, docs } = r;
       let score: number;
-      if (ruleTypeToLint === 'DESIGN') {
-        const fix = (r as DesignRuleModule).optimizer(info.dataProps, spec);
+      if (isDesignRuleModule(r)) {
+        const fix = r.optimizer(info.dataProps, spec);
         // no fix -> means no violation
         const score = Object.keys(fix).length === 0 ? 1 : 0;
         lints.push({ type, id, score, fix, docs });
       } else {
-        const { weight, extra } = r.option || {};
+        const { weight } = r.option || {};
         // no weight for linter's result
-        const score = (r as ChartRuleModule).validator({ ...info, weight, ...extra }) as number;
+        let score: number;
+        if (isCustomValidator(r.validator)) {
+          const { customArgs } = r.validator.customArgs;
+          r.validator.func({
+            ...info,
+            weight,
+            ...customArgs,
+          });
+        } else {
+          score = r.validator({ ...info, weight }) as number;
+        }
         lints.push({ type, id, score, docs });
       }
       log.push({ phase: 'LINT', ruleId: id, score, base: score, weight: 1, ruleType: type });

--- a/packages/chart-advisor/src/ruler/interface.ts
+++ b/packages/chart-advisor/src/ruler/interface.ts
@@ -83,10 +83,6 @@ export interface ChartRuleConfig {
    * whether to ignore the rule
    */
   off?: boolean;
-  /**
-   * user customized parameters of Validator
-   */
-  extra?: Record<string, any>;
 }
 
 /**

--- a/packages/chart-advisor/src/ruler/interface.ts
+++ b/packages/chart-advisor/src/ruler/interface.ts
@@ -57,8 +57,14 @@ export interface Info {
 /**
  * @public
  */
-export type Validator = (args: Info) => number | boolean;
-export type Trigger = (args: Info) => boolean;
+export type ValidatorFunction = (args: Info) => number | boolean;
+export type TriggerFunction = (args: Info) => boolean;
+
+export type CustomValidator = { func: ValidatorFunction; customArgs?: Record<string, any> };
+export type CustomTrigger = { func: TriggerFunction; customArgs?: Record<string, any> };
+
+export type Validator = ValidatorFunction | CustomValidator;
+export type Trigger = TriggerFunction | CustomTrigger;
 
 export type Optimizer = (
   dataProps: BasicDataPropertyForAdvice[] | BasicDataPropertyForAdvice | Partial<analyzer.GraphProps>,

--- a/packages/chart-advisor/src/ruler/utils.ts
+++ b/packages/chart-advisor/src/ruler/utils.ts
@@ -1,7 +1,7 @@
 import { intersects } from '../utils';
 
 import type { LevelOfMeasurement as LOM, DataPrerequisiteJSON } from '@antv/ckb';
-import type { BasicDataPropertyForAdvice } from './interface';
+import type { BasicDataPropertyForAdvice, CustomTrigger, CustomValidator, DesignRuleModule } from './interface';
 
 export function compare(f1: any, f2: any) {
   if (f1.distinct < f2.distinct) {
@@ -35,3 +35,15 @@ export function verifyDataProps(dataPre: DataPrerequisiteJSON, dataProps: BasicD
 export function isUndefined(value: any) {
   return value === undefined;
 }
+
+export const isDesignRuleModule = (props: any): props is DesignRuleModule => {
+  return props.type === 'DESIGN';
+};
+
+export const isCustomTrigger = (props: any): props is CustomTrigger => {
+  return props.func !== undefined;
+};
+
+export const isCustomValidator = (props: any): props is CustomValidator => {
+  return props.func !== undefined;
+};


### PR DESCRIPTION
Change the API of **Validator** and **Trigger**, enable customized arguments.
Validator and Trigger now can be:
- a function
- an object including a function and custom arguments
<img width="693" alt="截屏2022-08-08 17 30 15" src="https://user-images.githubusercontent.com/73281388/183386711-b205a94e-0beb-4fc4-a423-450a953cca1c.png">

