### PR TITLE
refactor(ava/data): migrate and improve utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
-      "prettier --write"
-    ],
-    "packages/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
       "jest --bail --findRelatedTests"
     ]
   },

--- a/packages/ava/src/__tests__/data/utils/common.test.ts
+++ b/packages/ava/src/__tests__/data/utils/common.test.ts
@@ -1,0 +1,22 @@
+import { unique, range, assert, isParentChild } from '../../../data/utils/common';
+
+test('unique', () => {
+  const data = [1, 2, 3, 3, 2, 1];
+  expect(unique(data)).toStrictEqual([1, 2, 3]);
+});
+
+test('range', () => {
+  const data = 4;
+  expect(range(data)).toStrictEqual([0, 1, 2, 3]);
+});
+
+test('assert', () => {
+  expect(() => assert(false, 'It is false!')).toThrow('It is false!');
+});
+
+test('isParentChild', () => {
+  expect(isParentChild(['a', 'b', 'c'], [1, 2, 3])).toBe(true);
+  expect(isParentChild(['a', 'a', 'c'], [1, 1, 3])).toBe(true);
+  expect(isParentChild(['a', 'a', 'c'], [1, 2, 3])).toBe(true);
+  expect(isParentChild(['a', 'b', 'c'], [1, 1, 3])).toBe(false);
+});

--- a/packages/ava/src/__tests__/data/utils/isType/isDateString.test.ts
+++ b/packages/ava/src/__tests__/data/utils/isType/isDateString.test.ts
@@ -1,0 +1,54 @@
+import { getIsoDatePatterns, getIsoTimePatterns, isDateString } from '../../../../data/utils/isType/isDateString';
+
+describe('func: isDateString', () => {
+  test('check a string is a date', () => {
+    expect(isDateString('1991')).toBe(true);
+    expect(isDateString('1890')).toBe(true);
+    expect(isDateString('1722')).toBe(false);
+    expect(isDateString('3013')).toBe(false);
+    expect(isDateString('2010 W08 1')).toBe(true);
+    expect(isDateString('2010-W081')).toBe(false);
+    expect(isDateString('2010-08-01')).toBe(true);
+    expect(isDateString('20100801')).toBe(false);
+    expect(isDateString('2010/08/01')).toBe(true);
+    expect(isDateString('2020/01/01')).toBe(true);
+    expect(isDateString('12/08/1999')).toBe(true);
+    expect(isDateString('1/1/1999')).toBe(true);
+    expect(isDateString('1999-01')).toBe(true);
+    expect(isDateString('1999-200')).toBe(true);
+    expect(isDateString('1999-367')).toBe(false);
+    expect(isDateString('2010-08-01 20:00:00')).toBe(true);
+    expect(isDateString('20:00:00')).toBe(true);
+    expect(isDateString('20:00:00Z')).toBe(true);
+    expect(isDateString('20:00:00+08:00')).toBe(true);
+    expect(isDateString('20:00:00-08:00')).toBe(true);
+    expect(isDateString('20:00:00.299-08:00')).toBe(true);
+    expect(isDateString('20:00:00.299')).toBe(true);
+    expect(isDateString('200000,299')).toBe(false);
+  });
+
+  test('strictly recognize number as date', () => {
+    expect(isDateString('997815')).toBe(false);
+    expect(isDateString('1135028')).toBe(false);
+    expect(isDateString('5388715')).toBe(false);
+  });
+});
+
+describe('Not strict', () => {
+  const isoDatePatternsNotStrict = getIsoDatePatterns(false);
+  const isoTimePatternsNotStrict = getIsoTimePatterns(false);
+
+  expect(isoDatePatternsNotStrict).toStrictEqual([
+    '(18|19|20)\\d{2}',
+    '(18|19|20)\\d{2}([-_./\\s])?W([0-4]\\d|5[0-2])(([-_./\\s])?([1-7]))?',
+    '(0?[1-9]|1[012])([-_./\\s])?(0?[1-9]|[12]\\d|3[01])([-_./\\s])?(18|19|20)\\d{2}',
+    '(18|19|20)\\d{2}([-_./\\s])?(0?[1-9]|1[012])([-_./\\s])?(0?[1-9]|[12]\\d|3[01])',
+    '(18|19|20)\\d{2}([-_./\\s])?(0?[1-9]|1[012])',
+    '(18|19|20)\\d{2}([-_./\\s])?((([0-2]\\d|3[0-5])\\d)|36[0-6])',
+  ]);
+
+  expect(isoTimePatternsNotStrict).toStrictEqual([
+    '(0?\\d|1\\d|2[0-4]):?(0?\\d|[012345]\\d):?(0?\\d|[012345]\\d)([.,]\\d{1,4})?(Z|[+-](0?\\d|1\\d|2[0-4])(:(0?\\d|[012345]\\d))?)?',
+    '(0?\\d|1\\d|2[0-4]):?(0?\\d|[012345]\\d)?(Z|[+-](0?\\d|1\\d|2[0-4])(:(0?\\d|[012345]\\d))?)',
+  ]);
+});

--- a/packages/ava/src/__tests__/data/utils/isType/isType.test.ts
+++ b/packages/ava/src/__tests__/data/utils/isType/isType.test.ts
@@ -1,0 +1,76 @@
+import {
+  isArray,
+  isBasicType,
+  isBoolean,
+  isDate,
+  isFloat,
+  isInteger,
+  isNil,
+  isNumber,
+  isObject,
+  isString,
+} from '../../../../data/utils/isType';
+
+test('isNull', () => {
+  const data = 'null';
+  expect(isNil(data)).toBe(true);
+});
+
+test('isString', () => {
+  const data = 'str';
+  expect(isString(data)).toBe(true);
+});
+
+test('isNumber', () => {
+  const data1 = 201;
+  expect(isNumber(data1)).toBe(true);
+
+  const data2 = '5.2';
+  expect(isNumber(data2, true)).toBe(true);
+});
+
+test('isInteger', () => {
+  const data1 = 1;
+  expect(isInteger(data1)).toBe(true);
+
+  const data2 = '1';
+  expect(isInteger(data2, true)).toBe(true);
+});
+
+test('isFloat', () => {
+  const data1 = 1.2;
+  expect(isFloat(data1)).toBe(true);
+
+  const data2 = '1.2';
+  expect(isFloat(data2, true)).toBe(true);
+});
+
+test('isDate', () => {
+  const data1 = new Date();
+  expect(isDate(data1)).toBe(true);
+
+  const data2 = '2021-09-24';
+  expect(isDate(data2, true)).toBe(true);
+});
+
+test('isBoolean', () => {
+  const data1 = true;
+  expect(isBoolean(data1)).toBe(true);
+
+  const data2 = ['是', '否'];
+  expect(isBoolean(data2, true)).toBe(true);
+});
+
+test('isObject', () => {
+  const data = { a: 1 };
+  expect(isObject(data)).toBe(true);
+});
+
+test('isArray', () => {
+  const data = [1, 2, 3];
+  expect(isArray(data)).toBe(true);
+});
+
+test('isBasicType', () => {
+  expect(isBasicType(5)).toBeTruthy();
+});

--- a/packages/ava/src/data/utils/common.ts
+++ b/packages/ava/src/data/utils/common.ts
@@ -1,0 +1,55 @@
+import { isArray } from './isType';
+
+/**
+ * Return an array with unique elements
+ * @param value
+ */
+export function unique(value: unknown[]): unknown[] {
+  return Array.from(new Set(value));
+}
+
+/**
+ * Generate an array from 0 to number.
+ * @param number
+ */
+export function range(number: Number) {
+  return [...Array(number).keys()];
+}
+
+/**
+ * assert
+ * @param condition
+ * @param errorMessage
+ */
+export function assert(condition: unknown, errorMessage?: string): asserts condition {
+  if (!condition) throw new Error(errorMessage);
+}
+
+/**
+ * Check parent-child relationship. A child has only one parent, but a parent can have more children.
+ * @param parent
+ * @param child
+ */
+export function isParentChild(parent: (string | number)[], child: (string | number)[]): boolean {
+  if (
+    !isArray(parent) ||
+    parent.length === 0 ||
+    !isArray(child) ||
+    child.length === 0 ||
+    parent.length !== child.length
+  )
+    return false;
+
+  const record: Record<string | number, any> = {};
+  for (let i = 0; i < child.length; i += 1) {
+    const c = child[i];
+    const p = parent[i];
+    if (!record[c]) {
+      record[c] = p;
+    } else if (record[c] !== p) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/ava/src/data/utils/index.ts
+++ b/packages/ava/src/data/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Utils used internally by ava.
+ */
+
+export * from './common';
+export * from './isType';

--- a/packages/ava/src/data/utils/isType/constants.ts
+++ b/packages/ava/src/data/utils/isType/constants.ts
@@ -1,0 +1,23 @@
+export const SPECIAL_BOOLEANS = [
+  [true, false],
+  [0, 1],
+  ['true', 'false'],
+  ['Yes', 'No'],
+  ['True', 'False'],
+  ['0', '1'],
+  ['是', '否'],
+];
+
+// For isDateString.ts
+export const DELIMITER = '([-_./\\s])';
+export const YEAR = '(18|19|20)\\d{2}';
+export const MONTH = '(0?[1-9]|1[012])';
+export const DAY = '(0?[1-9]|[12]\\d|3[01])';
+export const WEEK = '([0-4]\\d|5[0-2])';
+export const WEEKDAY = '([1-7])';
+export const HOUR = '(0?\\d|1\\d|2[0-4])';
+export const MINUTE = '(0?\\d|[012345]\\d)';
+export const SECOND = MINUTE;
+export const MILLISECOND = '\\d{1,4}';
+export const YEARDAY = '((([0-2]\\d|3[0-5])\\d)|36[0-6])';
+export const OFFSET = `(Z|[+-]${HOUR}(:${MINUTE})?)`;

--- a/packages/ava/src/data/utils/isType/index.ts
+++ b/packages/ava/src/data/utils/isType/index.ts
@@ -1,0 +1,76 @@
+import { SPECIAL_BOOLEANS } from './constants';
+import { isDateString } from './isDateString';
+
+export function isNil(value: unknown) {
+  return value === null || value === undefined || value === '' || Number.isNaN(value as number) || value === 'null';
+}
+
+export function isString(value: unknown) {
+  return typeof value === 'string';
+}
+
+function isNumberString(value: string) {
+  let hasDot = false;
+  let tempValue = value;
+  if (/^[+-]/.test(tempValue)) {
+    tempValue = tempValue.slice(1);
+  }
+  for (let i = 0; i < tempValue.length; i += 1) {
+    const char = tempValue[i];
+    if (char === '.') {
+      if (hasDot === false) {
+        hasDot = true;
+      } else {
+        return false;
+      }
+    }
+    if (char !== '.' && !/[0-9]/.test(char)) {
+      return false;
+    }
+  }
+  return tempValue.trim() !== '';
+}
+
+export function isNumber(value: unknown, checkString?: boolean) {
+  if (typeof value === 'number') return true;
+  if (checkString && isString(value)) return isNumberString(value as string);
+  return false;
+}
+
+export function isInteger(value: unknown, checkString?: boolean) {
+  if (typeof value === 'number') return Number.isInteger(value);
+  if (checkString && isString(value) && isNumberString(value as string)) return !(value as string).includes('.');
+  return false;
+}
+
+export function isFloat(value: unknown, checkString?: boolean) {
+  if (typeof value === 'number') return !Number.isNaN(value) && !Number.isInteger(value);
+  if (checkString && isString(value) && isNumberString(value as string)) return (value as string).includes('.');
+  return false;
+}
+
+export function isDate(value: unknown, checkString?: boolean): boolean {
+  if (value && Object.getPrototypeOf(value) === Date.prototype) return true;
+  if (checkString && isString(value)) return isDateString(value as string);
+  return false;
+}
+
+export function isBoolean(value: unknown, checkSpecialBoolean?: boolean) {
+  return checkSpecialBoolean
+    ? SPECIAL_BOOLEANS.some((list: unknown[]) => {
+        return (value as unknown[]).every((item: unknown) => list.includes(item));
+      })
+    : typeof value === 'boolean';
+}
+
+export function isObject(value: unknown) {
+  return value && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+export function isArray(value: unknown) {
+  return Array.isArray(value);
+}
+
+export function isBasicType(value: unknown) {
+  return !isArray(value) && !isObject(value);
+}

--- a/packages/ava/src/data/utils/isType/isDateString.ts
+++ b/packages/ava/src/data/utils/isType/isDateString.ts
@@ -1,0 +1,78 @@
+/**
+ * Check whether the string is a date.
+ */
+
+import {
+  DAY,
+  DELIMITER,
+  HOUR,
+  MILLISECOND,
+  MINUTE,
+  MONTH,
+  OFFSET,
+  SECOND,
+  WEEK,
+  WEEKDAY,
+  YEAR,
+  YEARDAY,
+} from './constants';
+
+/**
+ * Get ISO 8601 date regular expression string array
+ * Reference: https://www.cl.cam.ac.uk/~mgk25/iso-time.html
+ * @param strict Require delimiter or not
+ */
+export function getIsoDatePatterns(strict = true) {
+  return [
+    // 1991
+    `${YEAR}`,
+    // 1999-W12-7
+    `${YEAR}${DELIMITER}${strict ? '' : '?'}W${WEEK}(${DELIMITER}${strict ? '' : '?'}${WEEKDAY})?`,
+    // 12-22-1999
+    `${MONTH}${DELIMITER}${strict ? '' : '?'}${DAY}${DELIMITER}${strict ? '' : '?'}${YEAR}`,
+    // 1999-12-22 19991222
+    `${YEAR}${DELIMITER}${strict ? '' : '?'}${MONTH}${DELIMITER}${strict ? '' : '?'}${DAY}`,
+    // 1999-12
+    `${YEAR}${DELIMITER}${strict ? '' : '?'}${MONTH}`,
+    // 1999-200
+    `${YEAR}${DELIMITER}${strict ? '' : '?'}${YEARDAY}`,
+  ];
+}
+
+/**
+ * Get ISO 8601 time regular expression string array
+ * Reference: https://www.cl.cam.ac.uk/~mgk25/iso-time.html
+ * @param strict Require DELIMITER or not
+ */
+export function getIsoTimePatterns(strict = true) {
+  return [
+    // 23:20:20Z 23:20:20+08:00 23:20:20-08:00
+    `${HOUR}:${strict ? '' : '?'}${MINUTE}:${strict ? '' : '?'}${SECOND}([.,]${MILLISECOND})?${OFFSET}?`,
+    // 23:20+08
+    `${HOUR}:${strict ? '' : '?'}${MINUTE}?${OFFSET}`,
+  ];
+}
+
+const isoDatePatterns = getIsoDatePatterns();
+const isoTimePatterns = getIsoTimePatterns();
+const isoDateAndTimePatterns = [...isoDatePatterns, ...isoTimePatterns];
+
+isoDatePatterns.forEach((d) => {
+  isoTimePatterns.forEach((t) => {
+    isoDateAndTimePatterns.push(`${d}[T\\s]${t}`);
+  });
+});
+
+const isoDateAndTimeRegs: RegExp[] = isoDateAndTimePatterns.map((pattern) => {
+  return new RegExp(`^${pattern}$`);
+});
+
+export function isDateString(value: string): boolean {
+  for (let i = 0; i < isoDateAndTimeRegs.length; i += 1) {
+    const reg = isoDateAndTimeRegs[i];
+    if (reg.test(value.trim())) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Add utils used internally by ava.
Some utils might be moved to `ava/utils` after careful consideration. We have already had this idea in the [prev PR](https://github.com/antvis/AVA/pull/477/files#r1019152354).