### PR TITLE
chore: optimize ava-react rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coverage:ava-react": "cd ./packages/ava-react && npm run coverage",
     "build:ava": "cd ./packages/ava && npm run build",
     "build:ava-react": "cd ./packages/ava-react && npm run build",
-    "build": "run-p build:*",
+    "build": "run-s build:*",
     "clean": "git clean -dfx",
     "setup:demo": "cd demo && npm install",
     "start:demo": "cd demo && npm start",
@@ -45,7 +45,9 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
+      "prettier --write"
+    ],
+    "packages/*.{js,jsx,ts,tsx}": [
       "jest --bail --findRelatedTests"
     ]
   },
@@ -56,7 +58,6 @@
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
-    "@rollup/plugin-json": "^4.1.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^23.3.12",
@@ -84,9 +85,14 @@
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-typescript": "^8.2.5",
+    "lodash": "^4.17.21",
     "rollup": "^2.56.2",
+    "rollup-plugin-filesize": "^9.1.1",
+    "rollup-plugin-optimize-lodash-imports": "^1.0.2",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/ava-react/package.json
+++ b/packages/ava-react/package.json
@@ -37,9 +37,9 @@
     "format": "npm run prettier-fix && npm run lint-fix",
     "lint-staged": "lint-staged",
     "clean": "rimraf lib esm dist",
-    "build:umd": "rimraf ./dist && rollup -c",
-    "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",
-    "build:esm": "rimraf ./esm && tsc --module es6 --outDir esm",
+    "build:esm": "rimraf ./esm && cross-env FORMAT=esm rollup -c",
+    "build:cjs": "rimraf ./lib && cross-env FORMAT=cjs rollup -c",
+    "build:umd": "rimraf ./dist && cross-env FORMAT=umd rollup -c",
     "build": "run-p build:*",
     "test": "jest",
     "coverage": "jest --coverage",
@@ -53,17 +53,33 @@
   },
   "dependencies": {
     "@antv/ava": "3.0.0-alpha.0",
-    "tslib": "^2.3.1"
+    "canvg": "^4.0.1",
+    "lodash": "^4.17.21",
+    "styled-components": "^5.3.5",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
+    "@types/lodash": "^4.14.180",
+    "@types/react": "^17.0.15",
+    "@types/react-dom": "^17.0.9",
+    "@types/styled-components": "^5.1.25",
+    "@types/uuid": "^8.3.1",
+    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "jest": "^24.9.0",
     "lint-staged": "^11.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",
     "typescript": "4.3.5"
+  },
+  "peerDependencies": {
+    "antd": ">=4.16.13",
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }

--- a/packages/ava-react/rollup.config.js
+++ b/packages/ava-react/rollup.config.js
@@ -1,8 +1,3 @@
-import rollupConfig from '../../rollup.config';
+import rollupReactConfig from '../../rollup.config';
 
-export default rollupConfig('ts', {
-  input: './src/index.ts',
-  output: {
-    name: 'AVAReact',
-  },
-});
+export default rollupReactConfig('react', 'AVAReact');

--- a/packages/ava-react/tsconfig.json
+++ b/packages/ava-react/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "declaration": true,
-    "declarationDir": "./lib"
+    "declaration": true
   },
   "include": ["./src"]
 }

--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -53,12 +53,12 @@
     ]
   },
   "dependencies": {
-    "@types/react": "^18.0.25",
     "@antv/antv-spec": "^0.1.0-alpha.18",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
+    "@types/react": "^17.0.15",
     "eslint": "^7.32.0",
     "jest": "^24.9.0",
     "lint-staged": "^11.0.1",

--- a/packages/ava/rollup.config.js
+++ b/packages/ava/rollup.config.js
@@ -1,8 +1,3 @@
 import rollupConfig from '../../rollup.config';
 
-export default rollupConfig('ts', {
-  input: './src/index.ts',
-  output: {
-    name: 'AVA',
-  },
-});
+export default rollupConfig('ts', 'AVA');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,24 +1,98 @@
+import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import typescript from '@rollup/plugin-typescript';
-import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
+import json from '@rollup/plugin-json';
+import filesize from 'rollup-plugin-filesize';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import optimizeLodashImports from 'rollup-plugin-optimize-lodash-imports';
+import { kebabCase } from 'lodash';
 
-export default (type, options, explugins = []) => {
-  const configs = {
-    input: options.input,
-    output: {
-      file: './dist/index.min.js',
-      format: 'umd',
-      sourcemap: false,
-      ...options.output,
-    },
-    plugins: [resolve(), commonjs(), typescript(), terser(), json(), ...explugins],
-  };
+/**
+ * @param name upper camel case
+ */
+export default (type, name, config = {}) => {
+  const { plugins: extraPlugins = [], globals = {}, ...others } = config;
 
-  if (type === 'react') {
-    configs.external = ['react', 'react-dom', '@antv/g2plot'];
+  if (type === 'ts') {
+    const configs = {
+      input: './src/index.ts',
+      output: {
+        file: './dist/index.min.js',
+        format: 'umd',
+        sourcemap: false,
+        name,
+      },
+      plugins: [resolve(), commonjs(), typescript(), terser(), json(), ...extraPlugins],
+    };
+
+    return configs;
   }
 
-  return configs;
+  // 👇 otherwise, build react comp
+
+  const format = process.env.FORMAT;
+
+  const OUT_DIR_NAME_MAP = {
+    esm: 'esm',
+    cjs: 'lib',
+    umd: 'dist',
+  };
+
+  const outDir = OUT_DIR_NAME_MAP[format];
+
+  const output = {
+    name,
+    format,
+    preserveModules: format === 'esm',
+    sourcemap: true,
+    preserveModulesRoot: 'src',
+  };
+
+  const plugins = [
+    // Rewrites lodash imports to be specific for easier tree-shaking.
+    optimizeLodashImports(),
+
+    // Seamless integration between Rollup and Typescript.
+    typescript({
+      outDir,
+    }),
+
+    // Allow Rollup to resolve modules from `node_modules`, since it only
+    // resolves local modules by default.
+    resolve({
+      browser: true,
+    }),
+
+    // Allow Rollup to resolve CommonJS modules, since it only resolves ES2015
+    // modules by default.
+    commonjs({
+      include: /node_modules/,
+    }),
+
+    filesize(),
+    ...extraPlugins,
+  ];
+
+  // If external is not specified, peerDeps external will be removed by default
+  if (!others.external) plugins.unshift(peerDepsExternal());
+
+  if (format === 'umd') {
+    output.file = `dist/${kebabCase(name)}.min.js`;
+    plugins.push(terser());
+    output.globals = {
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      ...globals,
+    };
+  } else {
+    output.dir = outDir;
+  }
+
+  return {
+    input: 'src/index.ts',
+    output,
+    plugins,
+    ...others,
+  };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["node_modules", "**/esm", "**/lib", "**/dist", "**/build"]
 }


### PR DESCRIPTION
- use separately rollup config to build ts and react pkg;
- init ava-react repo package.json;
- add chart id to avoid types error;