### PR TITLE
refactor(ava): improve imports and exports related to ckb and data

### DIFF
--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -64,6 +64,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@antv/color-schema": "^0.2.3",
     "@stdlib/types": "^0.0.12",
     "@types/d3-array": "^3.0.1",
     "@types/jest": "^23.3.12",

--- a/packages/ava/src/advisor/advise-pipeline/advicesForChart.ts
+++ b/packages/ava/src/advisor/advise-pipeline/advicesForChart.ts
@@ -8,14 +8,14 @@ import { cloneDeep } from '../utils';
 
 import { dataToAdvices } from './data-to-advices';
 
-import type { ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { AdviseResult, ChartAdviseParams } from '../types';
 import type { BasicDataPropertyForAdvice, RuleModule } from '../ruler';
 
 export function advicesForChart(
   params: ChartAdviseParams,
   exportLog = false,
-  ckb: ChartKnowledgeBase,
+  ckb: CkbTypes.ChartKnowledgeBase,
   ruleBase: Record<string, RuleModule>
 ): AdviseResult {
   const { data, dataProps, smartColor, options, colorOptions } = params;

--- a/packages/ava/src/advisor/advise-pipeline/data-to-advices.ts
+++ b/packages/ava/src/advisor/advise-pipeline/data-to-advices.ts
@@ -1,15 +1,13 @@
-// TODO
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { hexToColor, colorToHex, paletteGeneration, colorSimulation } from '@antv/smart-color';
 
 import { deepMix, computeScore } from '../utils';
-import { CHART_IDS } from '../../ckb/constants';
+import { CHART_IDS } from '../../ckb';
 
 import { getChartTypeSpec } from './spec-mapping';
 
 import type { SimulationType } from '@antv/smart-color';
 import type { ColorSchemeType } from '@antv/color-schema';
-import type { ChartKnowledge, ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { Specification, Data } from '../../common/types';
 import type { BasicDataPropertyForAdvice, DesignRuleModule, RuleModule } from '../ruler/type';
 import type {
@@ -40,7 +38,7 @@ declare type ChartID = typeof CHART_IDS[number];
  */
 function scoreRules(
   chartType: ChartID | string,
-  chartWIKI: ChartKnowledgeBase,
+  chartWIKI: CkbTypes.ChartKnowledgeBase,
   dataProps: BasicDataPropertyForAdvice[],
   ruleBase: Record<string, RuleModule>,
   options?: PipeAdvisorOptions
@@ -205,7 +203,7 @@ function applySmartColor(
 export function dataToAdvices(
   data: Data,
   dataProps: BasicDataPropertyForAdvice[],
-  chartWIKI: Record<string, ChartKnowledge>,
+  chartWIKI: Record<string, CkbTypes.ChartKnowledge>,
   ruleBase: Record<string, RuleModule>,
   smartColor?: boolean,
   options?: PipeAdvisorOptions,

--- a/packages/ava/src/advisor/advise-pipeline/spec-mapping.ts
+++ b/packages/ava/src/advisor/advise-pipeline/spec-mapping.ts
@@ -4,20 +4,19 @@
  * 在 CKB 中增加 encode 相关描述，让这里的 spec mapping 简化
  */
 
-import { CHART_IDS } from '../../ckb/constants';
-import { pearson } from '../../data/statistics';
-import { isParentChild } from '../../data/utils';
+import { CHART_IDS } from '../../ckb';
+import { pearson, isParentChild } from '../../data';
 import { compare, hasSubset, intersects } from '../utils';
 
 import type { Data } from '../../common/types';
-import type { ChartKnowledge, LevelOfMeasurement as LOM } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { Advice } from '../types';
 import type { BasicDataPropertyForAdvice } from '../ruler';
 
 type EncodingType = 'quantitative' | 'temporal' | 'ordinal' | 'nominal'; // TODO support in AntVSpec | 'geojson';
 declare type ChartID = typeof CHART_IDS[number];
 
-function LOM2EncodingType(lom: LOM): EncodingType {
+function LOM2EncodingType(lom: CkbTypes.LevelOfMeasurement): EncodingType {
   switch (lom) {
     case 'Nominal':
       return 'nominal';
@@ -615,7 +614,7 @@ export function getChartTypeSpec(
   chartType: string,
   data: Data,
   dataProps: BasicDataPropertyForAdvice[],
-  chartKnowledge?: ChartKnowledge
+  chartKnowledge?: CkbTypes.ChartKnowledge
 ) {
   // step 0: check whether the chartType is default in `ChartID`
   // if not, use customized `toSpec` function

--- a/packages/ava/src/advisor/advisor.ts
+++ b/packages/ava/src/advisor/advisor.ts
@@ -4,7 +4,7 @@ import { processRuleCfg } from './ruler';
 import { advicesForChart } from './advise-pipeline';
 import { checkRules } from './lint-pipeline/check-rules';
 
-import type { ChartKnowledgeBase } from '../ckb/types';
+import type { CkbTypes } from '../ckb';
 import type { RuleModule } from './ruler';
 import type {
   AdvisorConfig,
@@ -33,7 +33,7 @@ export class Advisor {
   /**
    * CKB used for advising
    */
-  ckb: ChartKnowledgeBase;
+  ckb: CkbTypes.ChartKnowledgeBase;
 
   /**
    * rule base used for advising

--- a/packages/ava/src/advisor/lint-pipeline/check-rules.ts
+++ b/packages/ava/src/advisor/lint-pipeline/check-rules.ts
@@ -8,7 +8,7 @@ import { DataFrame } from '../../data';
 import { getChartType } from './getChartType';
 import { lintRules } from './lintRules';
 
-import type { ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { LintResult, ScoringResultForRule, LintParams, Lint } from '../types';
 import type { BasicDataPropertyForAdvice, RuleModule } from '../ruler';
 import type { Datum } from '../../common/types';
@@ -16,7 +16,7 @@ import type { Datum } from '../../common/types';
 export function checkRules(
   params: LintParams,
   ruleBase: Record<string, RuleModule>,
-  ckb: ChartKnowledgeBase
+  ckb: CkbTypes.ChartKnowledgeBase
 ): LintResult {
   const { spec, options } = params;
   let { dataProps } = params;

--- a/packages/ava/src/advisor/lint-pipeline/lintRules.ts
+++ b/packages/ava/src/advisor/lint-pipeline/lintRules.ts
@@ -3,7 +3,7 @@ import { Info, RuleModule } from '../ruler';
 import type { Specification } from '../../common/types';
 import type { ScoringResultForRule, Lint } from '../types';
 import type { ChartRuleModule, DesignRuleModule } from '../ruler';
-import type { ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 
 // TODO：remove log param and console, add a func to return log
 export function lintRules(
@@ -12,7 +12,7 @@ export function lintRules(
   info: Info,
   log: ScoringResultForRule[],
   lints: Lint[],
-  ckb: ChartKnowledgeBase,
+  ckb: CkbTypes.ChartKnowledgeBase,
   spec?: Specification
 ) {
   const judge = (type: 'HARD' | 'SOFT' | 'DESIGN') => {

--- a/packages/ava/src/advisor/ruler/type.ts
+++ b/packages/ava/src/advisor/ruler/type.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import type { DataTypes } from '../../data';
-import type { LevelOfMeasurement as LOM, ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { Specification } from '../../common/types';
 
 /**
@@ -17,8 +17,8 @@ export type RuleType = 'HARD' | 'SOFT' | 'DESIGN';
 export interface BasicDataPropertyForAdvice {
   /** field name */
   readonly name?: string;
-  /** LOM */
-  readonly levelOfMeasurements?: LOM[];
+  /** LevelOfMeasurement */
+  readonly levelOfMeasurements?: CkbTypes.LevelOfMeasurement[];
   /** used for split column xy series */
   readonly rawData: any[];
   /** required types in DataTypes. FieldInfo */
@@ -47,7 +47,7 @@ export interface Preferences {
  */
 export interface Info {
   chartType?: string;
-  chartWIKI?: ChartKnowledgeBase;
+  chartWIKI?: CkbTypes.ChartKnowledgeBase;
   dataProps: BasicDataPropertyForAdvice[] | BasicDataPropertyForAdvice;
   purpose?: string;
   preferences?: Preferences;

--- a/packages/ava/src/advisor/ruler/utils.ts
+++ b/packages/ava/src/advisor/ruler/utils.ts
@@ -1,6 +1,6 @@
 import { intersects } from '../utils';
 
-import type { LevelOfMeasurement as LOM, DataPrerequisite } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 import type { BasicDataPropertyForAdvice } from './type';
 
 export function compare(f1: any, f2: any) {
@@ -14,9 +14,12 @@ export function compare(f1: any, f2: any) {
   return 0;
 }
 
-export function verifyDataProps(dataPre: DataPrerequisite, dataProps: BasicDataPropertyForAdvice[]) {
-  const fieldsLOMs: LOM[][] = dataProps.map((info: any) => {
-    return info.levelOfMeasurements as LOM[];
+export function verifyDataProps(
+  dataPre: CkbTypes.ChartKnowledge['dataPres'][number],
+  dataProps: BasicDataPropertyForAdvice[]
+) {
+  const fieldsLOMs: CkbTypes.LevelOfMeasurement[][] = dataProps.map((info: any) => {
+    return info.levelOfMeasurements as CkbTypes.LevelOfMeasurement[];
   });
   if (fieldsLOMs) {
     let lomCount = 0;

--- a/packages/ava/src/advisor/types.ts
+++ b/packages/ava/src/advisor/types.ts
@@ -1,8 +1,7 @@
 import type { ColorSchemeType } from '@antv/color-schema';
 import type { SimulationType } from '@antv/smart-color';
 /** AVA 包内跨模块引用 */
-import type { CkbConfig } from '../ckb/ckb';
-import type { Purpose } from '../ckb/types';
+import type { CkbTypes, CkbConfig } from '../ckb';
 import type { Specification, Data } from '../common/types';
 /** Advisor 模块内引用 */
 import type { RuleConfig, BasicDataPropertyForAdvice, Preferences, RuleType } from './ruler/type';
@@ -91,7 +90,7 @@ export type AdvisorOptions = {
    * Proportion
    * Composition
    */
-  purpose?: Purpose;
+  purpose?: CkbTypes.Purpose;
   /**
    * preference settings for landscape or portrait
    */
@@ -201,7 +200,7 @@ export interface ScoringResultForChartType {
 export type { Preferences } from './ruler/type';
 
 export interface LinterOptions {
-  purpose?: Purpose;
+  purpose?: CkbTypes.Purpose;
   preferences?: Preferences;
 }
 

--- a/packages/ava/src/advisor/utils/computeScore.ts
+++ b/packages/ava/src/advisor/utils/computeScore.ts
@@ -1,17 +1,17 @@
 import { Info, RuleModule } from '../ruler';
 import { DEFAULT_RULE_WEIGHTS } from '../constants';
-import { CHART_IDS } from '../../ckb/constants';
+import { CHART_IDS } from '../../ckb';
 
 import type { ScoringResultForRule } from '../types';
 import type { ChartRuleModule } from '../ruler/type';
-import type { ChartKnowledgeBase } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 
 const defaultWeights = DEFAULT_RULE_WEIGHTS;
 declare type ChartID = typeof CHART_IDS[number];
 
 const computeScore = (
   chartType: ChartID | string,
-  chartWIKI: ChartKnowledgeBase,
+  chartWIKI: CkbTypes.ChartKnowledgeBase,
   ruleBase: Record<string, RuleModule>,
   ruleType: 'HARD' | 'SOFT',
   info: Info,

--- a/packages/ava/src/ckb/index.ts
+++ b/packages/ava/src/ckb/index.ts
@@ -6,8 +6,6 @@
 //  b. EIC（exclude,include,custom）用法
 //  c. 图表类型分割的具体逻辑（比如 单色柱状图、多色柱状图 是否是两个id？条形图、柱状图呢？为什么）
 
-import * as CkbTypes from './types';
-
 // the main CKB API - ckb
 export { ckb } from './ckb';
 // CKB i18n functions
@@ -15,4 +13,5 @@ export { ckbDict } from './i18n';
 // CKB constants
 export * from './constants';
 // CKB types
-export { CkbTypes };
+export * as CkbTypes from './types';
+export type { CkbConfig } from './ckb';

--- a/packages/ava/src/ckb/types.ts
+++ b/packages/ava/src/ckb/types.ts
@@ -148,7 +148,7 @@ export type PureChartKnowledge = {
  *
  * @public
  */
-export interface ChartKnowledge {
+export type ChartKnowledge = {
   id: string;
   name: string;
   alias: string[];
@@ -162,7 +162,7 @@ export interface ChartKnowledge {
   channel: string[];
   recRate: string;
   toSpec?: (data: Data, dataProps: any) => Specification | null;
-}
+};
 
 /**
  * TS type of pure CKB(Chart Knowledge Base).

--- a/packages/ava/src/data/analysis/field/index.ts
+++ b/packages/ava/src/data/analysis/field/index.ts
@@ -1,4 +1,3 @@
-import { CkbTypes } from '../../../ckb';
 import {
   max,
   maxIndex,
@@ -26,6 +25,7 @@ import {
   unique,
 } from '../../utils';
 
+import type { CkbTypes } from '../../../ckb';
 import type { DateFieldInfo, FieldInfo, FieldMeta, NumberFieldInfo, StringFieldInfo, FieldType } from './types';
 
 /**

--- a/packages/ava/src/data/index.ts
+++ b/packages/ava/src/data/index.ts
@@ -1,3 +1,5 @@
 export * from './analysis';
 export * from './dataset';
+export * from './statistics';
+export * from './utils';
 export * as DataTypes from './types';

--- a/packages/ava/src/index.ts
+++ b/packages/ava/src/index.ts
@@ -19,8 +19,10 @@ export {
 
 // data
 export {
-  analyzeField,
-  DataTypes, // namespace of types
+  analyzeField, // Analyze field info
+  Series, // 1D data structure
+  DataFrame, // 2D data structure
+  DataTypes, // Namespace of types
 } from './data';
 
 // insight

--- a/packages/ava/src/insight/insights/checkers.ts
+++ b/packages/ava/src/insight/insights/checkers.ts
@@ -3,13 +3,13 @@ import { intersection } from 'lodash';
 import { Datum, SubjectInfo, InsightType } from '../types';
 import { DataProperty } from '../pipeline/preprocess';
 
-import type { LevelOfMeasurement } from '../../ckb/types';
+import type { CkbTypes } from '../../ckb';
 
 export type ExtractorChecker = (
   data: Datum[],
   subjectInfo: SubjectInfo,
   fieldPropsMap: Record<string, DataProperty>,
-  lom?: LevelOfMeasurement | LevelOfMeasurement[]
+  lom?: CkbTypes.LevelOfMeasurement | CkbTypes.LevelOfMeasurement[]
 ) => boolean;
 
 const fieldsQuantityChecker = (subjectInfo: SubjectInfo, dimensionsQuantity: number, measuresQuantity: number) => {
@@ -27,8 +27,8 @@ const generalCheckerFor1M1D: ExtractorChecker = (data, subjectInfo, fieldPropsMa
   // check dimension type
   if (
     Array.isArray(lom)
-      ? !intersection(fieldPropsMap[dimensions[0]]?.levelOfMeasurements, lom as LevelOfMeasurement[])?.length
-      : !fieldPropsMap[dimensions[0]]?.levelOfMeasurements?.includes(lom as LevelOfMeasurement)
+      ? !intersection(fieldPropsMap[dimensions[0]]?.levelOfMeasurements, lom as CkbTypes.LevelOfMeasurement[])?.length
+      : !fieldPropsMap[dimensions[0]]?.levelOfMeasurements?.includes(lom as CkbTypes.LevelOfMeasurement)
   )
     return false;
   return true;

--- a/packages/ava/src/insight/insights/extractors/categoryOutlier.ts
+++ b/packages/ava/src/insight/insights/extractors/categoryOutlier.ts
@@ -1,6 +1,6 @@
 import { sortBy } from 'lodash';
 
-import { distinct } from '../../../data/statistics';
+import { distinct } from '../../../data';
 import { IQR } from '../../algorithms';
 import { SignificanceBenchmark } from '../../constant';
 import { Datum, Measure, CategoryOutlierInfo } from '../../types';

--- a/packages/ava/src/insight/insights/extractors/lowVariance.ts
+++ b/packages/ava/src/insight/insights/extractors/lowVariance.ts
@@ -1,4 +1,4 @@
-import { coefficientOfVariance, mean } from '../../../data/statistics';
+import { coefficientOfVariance, mean } from '../../../data';
 
 import type { Datum, LowVarianceInfo, Measure } from '../../types';
 

--- a/packages/ava/src/insight/insights/extractors/timeSeriesOutlier.ts
+++ b/packages/ava/src/insight/insights/extractors/timeSeriesOutlier.ts
@@ -1,6 +1,6 @@
 import lowess from '@stdlib/stats-lowess';
 
-import { distinct } from '../../../data/statistics';
+import { distinct } from '../../../data';
 
 import { findOutliers } from './categoryOutlier';
 

--- a/packages/ava/src/insight/insights/util.ts
+++ b/packages/ava/src/insight/insights/util.ts
@@ -1,7 +1,7 @@
 import { mean } from 'lodash';
 import { cdf } from '@stdlib/stats/base/dists/normal';
 
-import { standardDeviation } from '../../data/statistics';
+import { standardDeviation } from '../../data';
 
 export const calculatePValue = (values: number[], target: number) => {
   const meanValue = mean(values);


### PR DESCRIPTION
- add full `data` exports
- `import type { CkbTypes }` instead of `import type { XxxType }`  in internal files
- `import { xxx }` from the root of each module   in internal files