### PR TITLE
feat(ava-react/insight-card): support render custom spec in insight card

### DIFF
--- a/packages/ava-react/common/styles/index.less
+++ b/packages/ava-react/common/styles/index.less
@@ -1,1 +1,3 @@
 @avar-prefix: avar;
+/** color for indicating active status of icon */
+@active-color: #3471f9;

--- a/packages/ava-react/src/InsightCard/InsightCard.tsx
+++ b/packages/ava-react/src/InsightCard/InsightCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 
 import { Empty, Row, Spin } from 'antd';
 import cx from 'classnames';
@@ -41,7 +41,7 @@ export const InsightCard: React.FC<InsightCardProps> = ({
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const calculateAndSetInsightPatterns = () => {
+  const calculateAndSetInsightPatterns = useCallback(() => {
     const { allData } = autoInsightOptions;
     setDataStatus('RUNNING');
     try {
@@ -56,7 +56,7 @@ export const InsightCard: React.FC<InsightCardProps> = ({
       setErrorMessage('');
     }
     setDataStatus('SUCCESS');
-  };
+  }, [measures, dimensions, autoInsightOptions]);
 
   useEffect(() => {
     // if patterns or visualizationSpecs is not empty, do not need generate insight patterns

--- a/packages/ava-react/src/InsightCard/InsightCard.tsx
+++ b/packages/ava-react/src/InsightCard/InsightCard.tsx
@@ -29,8 +29,8 @@ export const InsightCard: React.FC<InsightCardProps> = ({
   onCardExpose,
   onChange,
   onCopy,
-  insightGenerateOptions,
-  customContentSpecGenerator,
+  autoInsightOptions,
+  customContentSpec,
 }: InsightCardProps) => {
   const prefixCls = INSIGHT_CARD_PREFIX_CLS;
   const { measures = [], dimensions = [] } = defaultInsightInfo;
@@ -42,14 +42,14 @@ export const InsightCard: React.FC<InsightCardProps> = ({
   const ref = useRef<HTMLDivElement>(null);
 
   const calculateAndSetInsightPatterns = () => {
-    const { allData } = insightGenerateOptions;
+    const { allData } = autoInsightOptions;
     setDataStatus('RUNNING');
     try {
       const { insights } = getInsights(allData, {
         measures,
         dimensions,
         // todo 待 getInsights 支持传入 subspace 后增加传入 subspace
-        ...insightGenerateOptions,
+        ...autoInsightOptions,
       });
       setCurrentInsightInfo(insights[0]);
     } catch (err) {
@@ -64,17 +64,18 @@ export const InsightCard: React.FC<InsightCardProps> = ({
       setCurrentInsightInfo(defaultInsightInfo);
       return;
     }
-    // if patterns and visualizationSpecs are empty, use insightGenerateOptions to generate insight patterns
-    if (insightGenerateOptions) {
+    // if patterns and visualizationSpecs are empty, use autoInsightOptions to generate insight patterns
+    if (autoInsightOptions) {
       calculateAndSetInsightPatterns();
     }
-  }, [defaultInsightInfo, insightGenerateOptions]);
+  }, [defaultInsightInfo, autoInsightOptions]);
 
   const contentSpec = useMemo(() => {
     const defaultSpec = generateNarrativeVisSpec(currentInsightInfo);
-    return isFunction(customContentSpecGenerator)
-      ? customContentSpecGenerator?.(currentInsightInfo, defaultSpec)
-      : defaultSpec;
+    const customSpec = isFunction(customContentSpec)
+      ? customContentSpec?.(currentInsightInfo, defaultSpec)
+      : customContentSpec;
+    return customSpec ?? defaultSpec;
   }, [currentInsightInfo]);
 
   useEffect(() => {

--- a/packages/ava-react/src/InsightCard/Title/index.tsx
+++ b/packages/ava-react/src/InsightCard/Title/index.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 
 import cx from 'classnames';
-import { isFunction } from 'lodash';
+import { isFunction, uniq } from 'lodash';
 
 import { Toolbar } from '../Toolbar';
 import { ALGORITHM_NAME_MAP, INSIGHT_CARD_PREFIX_CLS } from '../constants';
 
-import type { InsightCardProps } from '../types';
+import type { InsightCardProps, InsightData } from '../types';
 
 import './index.less';
 
-export type TitleProps = Pick<InsightCardProps, 'algorithms' | 'measures' | 'headerTools' | 'title'>;
-export const Title: React.FC<TitleProps> = ({ title, algorithms, measures, headerTools }) => {
+export type TitleProps = Pick<InsightCardProps, 'headerTools' | 'title'> &
+  Pick<InsightData, 'measures' | 'dimensions' | 'patterns'>;
+export const Title: React.FC<TitleProps> = ({ title, patterns, measures, headerTools }) => {
   const prefixCls = INSIGHT_CARD_PREFIX_CLS;
-  const measureNames = measures?.map((measure) => measure.field).join(',');
+  const algorithms = uniq(patterns?.map((pattern) => pattern.type) ?? []);
+  const measureNames = uniq(measures?.map((measure) => measure.field)).join(',');
   const analysisName = algorithms.map((algorithm) => ALGORITHM_NAME_MAP[algorithm]).join(',') ?? '';
   const defaultTitle = (
     <div>

--- a/packages/ava-react/src/InsightCard/Title/index.tsx
+++ b/packages/ava-react/src/InsightCard/Title/index.tsx
@@ -6,17 +6,17 @@ import { isFunction, uniq } from 'lodash';
 import { Toolbar } from '../Toolbar';
 import { ALGORITHM_NAME_MAP, INSIGHT_CARD_PREFIX_CLS } from '../constants';
 
-import type { InsightCardProps, InsightData } from '../types';
+import type { InsightCardProps, InsightCardInfo } from '../types';
 
 import './index.less';
 
 export type TitleProps = Pick<InsightCardProps, 'headerTools' | 'title'> &
-  Pick<InsightData, 'measures' | 'dimensions' | 'patterns'>;
+  Pick<InsightCardInfo, 'measures' | 'dimensions' | 'patterns'>;
 export const Title: React.FC<TitleProps> = ({ title, patterns, measures, headerTools }) => {
   const prefixCls = INSIGHT_CARD_PREFIX_CLS;
-  const algorithms = uniq(patterns?.map((pattern) => pattern.type) ?? []);
+  const insightTypes = uniq(patterns?.map((pattern) => pattern.type) ?? []);
   const measureNames = uniq(measures?.map((measure) => measure.field)).join(',');
-  const analysisName = algorithms.map((algorithm) => ALGORITHM_NAME_MAP[algorithm]).join(',') ?? '';
+  const analysisName = insightTypes.map((algorithm) => ALGORITHM_NAME_MAP[algorithm]).join(',') ?? '';
   const defaultTitle = (
     <div>
       <span className={`${prefixCls}-measure-name`}>{measureNames}</span>

--- a/packages/ava-react/src/InsightCard/Toolbar/constants.ts
+++ b/packages/ava-react/src/InsightCard/Toolbar/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_TOOLS = ['copy'] as const;
+export const DEFAULT_TOOLS = ['copy', 'export'] as const;

--- a/packages/ava-react/src/InsightCard/Toolbar/defaultTools.tsx
+++ b/packages/ava-react/src/InsightCard/Toolbar/defaultTools.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CopyOutlined } from '@ant-design/icons';
+import { CopyOutlined, ExportOutlined } from '@ant-design/icons';
 import { Button, Tooltip } from 'antd';
 
 import { INSIGHT_CARD_PREFIX_CLS } from '../constants';
@@ -25,14 +25,23 @@ export const BaseIconButton: React.FC<BaseIconButtonProps> = ({ icon, onClick, d
 const defaultCopyButton = () => {
   return {
     type: 'copy',
-    description: 'copy insight content',
+    description: 'copy',
     icon: <CopyOutlined />,
+  };
+};
+
+const defaultExportButton = () => {
+  return {
+    type: 'export',
+    description: 'export',
+    icon: <ExportOutlined />,
   };
 };
 
 export const getDefaultTool = (type: DefaultToolType) => {
   const toolsFunctionMap = {
     copy: defaultCopyButton,
+    export: defaultExportButton,
   };
   return toolsFunctionMap[type]?.();
 };

--- a/packages/ava-react/src/InsightCard/Toolbar/index.less
+++ b/packages/ava-react/src/InsightCard/Toolbar/index.less
@@ -17,7 +17,4 @@
       color: @active-color;
     }
   }
-  &-like-icon-liked {
-    color: @active-color;
-  }
 }

--- a/packages/ava-react/src/InsightCard/Toolbar/index.tsx
+++ b/packages/ava-react/src/InsightCard/Toolbar/index.tsx
@@ -41,5 +41,5 @@ export const Toolbar = ({ tools = [], data }: ToolbarProps) => {
     return tool;
   });
 
-  return tools.length ? <div className={INSIGHT_CARD_PREFIX_CLS}>{toolButtons}</div> : null;
+  return tools.length ? <div className={`${INSIGHT_CARD_PREFIX_CLS}-toolbar`}>{toolButtons}</div> : null;
 };

--- a/packages/ava-react/src/InsightCard/Toolbar/types.ts
+++ b/packages/ava-react/src/InsightCard/Toolbar/types.ts
@@ -1,21 +1,21 @@
 import React from 'react';
 
 import type { ReactNode } from 'react';
-import type { InsightData } from '../types';
+import type { InsightCardInfo } from '../types';
 import type { DEFAULT_TOOLS } from './constants';
 
 export type Tool = {
   type: string;
   /** display icon */
-  icon?: ReactNode | ((type: string, data?: InsightData) => ReactNode);
+  icon?: ReactNode | ((type: string, data?: InsightCardInfo) => ReactNode);
   /** tool description, if assigned, it will show as a tooltip when icon is hovered */
-  description?: ReactNode | ((type: string, data?: InsightData) => ReactNode);
-  onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>, type: string, data?: InsightData) => void;
+  description?: ReactNode | ((type: string, data?: InsightCardInfo) => ReactNode);
+  onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>, type: string, data?: InsightCardInfo) => void;
 };
 
 export type ToolbarProps = {
   tools: Tool[];
-  data?: InsightData;
+  data?: InsightCardInfo;
 };
 
 export type DefaultToolType = (typeof DEFAULT_TOOLS)[number];

--- a/packages/ava-react/src/InsightCard/constants.tsx
+++ b/packages/ava-react/src/InsightCard/constants.tsx
@@ -17,6 +17,6 @@ export const ALGORITHM_NAME_MAP: Record<InsightType, string> = {
 /** default minimum height for card */
 export const CARD_CONTENT_HEIGHT = 48;
 /** default chart height in card */
-export const CHART_HEIGHT = 150;
+export const CHART_HEIGHT = 280;
 /** chart carousel plugin key  */
-export const CHART_CAROUSEL_PLUGIN_KEY = 'chartCarousel';
+export const DISPLAY_CHARTS_PLUGIN_KEY = 'charts';

--- a/packages/ava-react/src/InsightCard/index.less
+++ b/packages/ava-react/src/InsightCard/index.less
@@ -10,6 +10,7 @@
     'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: #fff;
   border-radius: 2px;
+  border: 1px solid #e8e8e8;
 }
 
 .@{prefix}-tools-container {

--- a/packages/ava-react/src/InsightCard/index.ts
+++ b/packages/ava-react/src/InsightCard/index.ts
@@ -1,0 +1,3 @@
+export type { ToolbarProps as InsightCardToolBarProps } from './Toolbar/types';
+export { InsightCard } from './InsightCard';
+export { InsightCardProps } from './types';

--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/ChartCarousel.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/ChartCarousel.tsx
@@ -8,9 +8,12 @@ import type { G2Spec } from '@antv/g2';
 
 export const ChartCarousel = ({
   charts,
+  height = CHART_HEIGHT,
+  width,
 }: {
-  /** 图表类 schema, any 是因为不限制具体的图表类型 */
   charts: G2Spec[];
+  height?: number;
+  width?: number;
 }) => {
   const [selectedChartIndex, setSelectedCardIndex] = useState(0);
 
@@ -23,10 +26,12 @@ export const ChartCarousel = ({
       label: (
         <span
           style={{
-            border: 'solid 1px',
-            borderColor: index === selectedChartIndex ? '#3471f9' : 'rgba(0,0,0,0.25)',
+            border: index === selectedChartIndex ? '1px solid rgba(0,0,0,0.15)' : '1px solid rgba(0,0,0,0.1)',
             borderRadius: '2px',
-            padding: '2px',
+            display: 'inline-block',
+            width: index === selectedChartIndex ? '18px' : '12px',
+            height: '4px',
+            backgroundColor: index === selectedChartIndex ? '#fff' : 'rgba(0,0,0,0.15)',
             cursor: 'pointer',
             margin: '2px',
           }}
@@ -41,9 +46,9 @@ export const ChartCarousel = ({
 
   return (
     <div className={`${INSIGHT_CARD_PREFIX_CLS}-chart-carousel`}>
-      <G2Chart spec={charts[selectedChartIndex]} height={CHART_HEIGHT} />
+      <G2Chart spec={charts[selectedChartIndex]} height={height} width={width} />
       {chartsOptions.length > 1 && (
-        <div style={{ marginTop: '4px', textAlign: 'center' }}>
+        <div style={{ textAlign: 'center' }}>
           {chartsOptions.map((option) => (
             <span key={option.value}>{option.label}</span>
           ))}

--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/ChartCarousel.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/ChartCarousel.tsx
@@ -6,7 +6,12 @@ import { G2Chart } from './G2Chart';
 
 import type { G2Spec } from '@antv/g2';
 
-export const ChartCarousel = ({ charts }: { charts: G2Spec[] }) => {
+export const ChartCarousel = ({
+  charts,
+}: {
+  /** 图表类 schema, any 是因为不限制具体的图表类型 */
+  charts: G2Spec[];
+}) => {
   const [selectedChartIndex, setSelectedCardIndex] = useState(0);
 
   const onSelect = (value: number) => {

--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
@@ -7,12 +7,21 @@ import { INSIGHT_CARD_PREFIX_CLS } from '../../constants';
 export const G2Chart = ({ spec, height, width }: { spec: G2Spec; height?: number; width?: number }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = React.useRef<Chart>(null);
+
   useEffect(() => {
     if (containerRef?.current) {
       chartRef.current = new Chart({ container: containerRef?.current, autoFit: true });
-      chartRef.current.options(spec);
+      chartRef.current.options({
+        width: containerRef.current?.clientWidth,
+        height: containerRef.current?.clientHeight,
+        ...spec,
+      });
     } else {
-      chartRef.current.options(spec);
+      chartRef.current.options({
+        width: containerRef.current?.clientHeight,
+        height: containerRef.current?.clientHeight,
+        ...spec,
+      });
     }
     chartRef.current.render();
   }, [spec]);

--- a/packages/ava-react/src/InsightCard/ntvPlugins/constants.ts
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/constants.ts
@@ -1,1 +1,0 @@
-export const CHART_CAROUSEL_PLUGIN_KEY = 'chartCarousel';

--- a/packages/ava-react/src/InsightCard/ntvPlugins/constants.ts
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/constants.ts
@@ -1,0 +1,1 @@
+export const CHART_CAROUSEL_PLUGIN_KEY = 'chartCarousel';

--- a/packages/ava-react/src/InsightCard/ntvPlugins/index.ts
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/index.ts
@@ -1,3 +1,5 @@
+import { chartsDisplayPlugin } from './plugins/chartPlugin';
+
 import type { NtvPluginType } from '@antv/ava-react';
 
-export const insightCardPresetPlugins: NtvPluginType[] = [];
+export const insightCardPresetPlugins: NtvPluginType[] = [chartsDisplayPlugin];

--- a/packages/ava-react/src/InsightCard/ntvPlugins/plugins/chartPlugin.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/plugins/chartPlugin.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { createCustomBlockFactory } from '../../../NarrativeTextVis';
-import { CHART_CAROUSEL_PLUGIN_KEY } from '../../constants';
 import { ChartCarousel } from '../components/ChartCarousel';
+import { CHART_CAROUSEL_PLUGIN_KEY } from '../constants';
 import { ChartsSchema } from '../types';
 
 /** plugins to display charts in ntv */

--- a/packages/ava-react/src/InsightCard/ntvPlugins/plugins/chartPlugin.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/plugins/chartPlugin.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
 import { createCustomBlockFactory } from '../../../NarrativeTextVis';
+import { DISPLAY_CHARTS_PLUGIN_KEY } from '../../constants';
 import { ChartCarousel } from '../components/ChartCarousel';
-import { CHART_CAROUSEL_PLUGIN_KEY } from '../constants';
 import { ChartsSchema } from '../types';
 
 /** plugins to display charts in ntv */
-export const chartCarouselPlugin = createCustomBlockFactory<ChartsSchema>({
-  key: CHART_CAROUSEL_PLUGIN_KEY,
+export const chartsDisplayPlugin = createCustomBlockFactory<ChartsSchema>({
+  key: DISPLAY_CHARTS_PLUGIN_KEY,
   render(item) {
-    const { value } = item;
-    if (value?.charts) {
-      return <ChartCarousel charts={value?.charts} />;
+    const { chartSpecs } = item;
+    if (chartSpecs) {
+      return <ChartCarousel charts={chartSpecs} />;
     }
     return null;
   },

--- a/packages/ava-react/src/InsightCard/ntvPlugins/types.ts
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/types.ts
@@ -3,7 +3,5 @@ import { NtvTypes } from '../../NarrativeTextVis';
 import type { G2Spec } from '@antv/g2';
 
 export type ChartsSchema = NtvTypes.CustomBlockElement & {
-  value: {
-    charts: G2Spec[];
-  };
+  chartSpecs: G2Spec[];
 };

--- a/packages/ava-react/src/InsightCard/types.ts
+++ b/packages/ava-react/src/InsightCard/types.ts
@@ -15,22 +15,22 @@ export type CommonProps = {
  * @description basic info of an insight
  * @description.zh-CN 洞察的基本信息
  */
-export type InsightCardInfo = Omit<InsightInfo, 'score' | 'patterns'> & {
+export type InsightCardInfo = Omit<InsightInfo, 'score' | 'patterns' | 'visualizationSpecs'> & {
   /**
- * analysis result data, if not defined, will be referred by insightGenerateOptions. One of `insightGenerateOptions` and `patterns` must be assigned
-  分析得到的洞察数据，`insightGenerateOptions` 和 `patterns` 至少有一个必须被赋值
-*/
+   * analysis result data, if not defined, will be referred by autoInsightOptions. One of `autoInsightOptions` and `patterns` must be assigned
+    分析得到的洞察数据，`autoInsightOptions` 和 `patterns` 至少有一个必须被赋值
+  */
   patterns?: PatternInfo[];
 };
 
 /** events that may be emitted by card */
 export type InsightCardEventHandlers = {
   /** events emitted when the card content copied */
-  onCopy?: (insight?: InsightCardInfo, dom?: HTMLElement) => void;
+  onCopy?: (insightInfo?: InsightCardInfo, dom?: HTMLElement) => void;
   /** events emitted when the card expose */
-  onCardExpose?: (insight?: InsightCardInfo, dom?: HTMLElement) => void;
+  onCardExpose?: (insightInfo?: InsightCardInfo, dom?: HTMLElement) => void;
   /** events emitted when insight data change */
-  onChange?: (insight?: InsightCardInfo, contentSpec?: NtvTypes.NarrativeTextSpec) => void;
+  onChange?: (insightInfo?: InsightCardInfo, contentSpec?: NtvTypes.NarrativeTextSpec) => void;
 };
 
 export type InsightCardProps = CommonProps &
@@ -43,15 +43,14 @@ export type InsightCardProps = CommonProps &
     headerTools?: Tool[];
     /** tools in the footer of card, by default, there are copy and share tools */
     footerTools?: Tool[];
-    /** options used to generate the insight, one of `insightGenerateOptions` and `patterns` must be assigned */
-    insightGenerateOptions?: Omit<InsightOptions, 'visualization' | 'dimensions' | 'measures'> & {
+    /** options used to generate the insight, one of `autoInsightOptions` and `patterns` must be assigned */
+    autoInsightOptions?: Omit<InsightOptions, 'visualization' | 'dimensions' | 'measures'> & {
       allData: { [x: string]: any }[];
     };
     /** function for customizing content */
-    customContentSpecGenerator?: (
-      insightMeta?: InsightCardInfo,
-      defaultSpec?: NtvTypes.NarrativeTextSpec
-    ) => NtvTypes.NarrativeTextSpec;
+    customContentSpec?:
+      | NtvTypes.NarrativeTextSpec
+      | ((insightInfo?: InsightCardInfo, defaultSpec?: NtvTypes.NarrativeTextSpec) => NtvTypes.NarrativeTextSpec);
     /** custom plugins, should pass if your customized schema includes special plugins ntv schema 中，自己定制的 plugins */
     extraPlugins?: NtvPluginType[];
   };

--- a/packages/ava-react/src/InsightCard/types.ts
+++ b/packages/ava-react/src/InsightCard/types.ts
@@ -2,7 +2,7 @@ import type { NtvTypes, NtvPluginType } from '@antv/ava-react';
 import type { CSSProperties, ReactNode } from 'react';
 import type { Tool } from './Toolbar/types';
 // TODO @chenluli export form insight module
-import type { InsightInfo, InsightType, PatternInfo } from '@antv/ava/lib/insight/types';
+import type { InsightInfo, InsightOptions, PatternInfo } from '@antv/ava/lib/insight/types';
 
 export type CardType = 'mini' | 'standard' | 'expand' | 'detail';
 
@@ -15,42 +15,41 @@ export type CommonProps = {
  * @description basic info of an insight
  * @description.zh-CN 洞察的基本信息
  */
-export type InsightData = Omit<InsightInfo, 'score' | 'patterns'> & {
+export type InsightCardInfo = Omit<InsightInfo, 'score' | 'patterns'> & {
   /**
-   * analysis result data, if not defined, will be referred by algorithms. One of `algorithms` and `patterns` must be assigned
-   * 分析得到的洞察数据，`insightGenerateConfig` 和 `patterns` 至少有一个必须被赋值
-   */
+ * analysis result data, if not defined, will be referred by insightGenerateOptions. One of `insightGenerateOptions` and `patterns` must be assigned
+  分析得到的洞察数据，`insightGenerateOptions` 和 `patterns` 至少有一个必须被赋值
+*/
   patterns?: PatternInfo[];
 };
 
 /** events that may be emitted by card */
 export type InsightCardEventHandlers = {
   /** events emitted when the card content copied */
-  onCopy?: (insight?: InsightData, dom?: HTMLElement) => void;
+  onCopy?: (insight?: InsightCardInfo, dom?: HTMLElement) => void;
   /** events emitted when the card expose */
-  onCardExpose?: (insight?: InsightData, dom?: HTMLElement) => void;
+  onCardExpose?: (insight?: InsightCardInfo, dom?: HTMLElement) => void;
   /** events emitted when insight data change */
-  onChange?: (insight?: InsightData, contentSpec?: NtvTypes.NarrativeTextSpec) => void;
+  onChange?: (insight?: InsightCardInfo, contentSpec?: NtvTypes.NarrativeTextSpec) => void;
 };
 
 export type InsightCardProps = CommonProps &
   InsightCardEventHandlers & {
     /** basic info of an insight */
-    insightInfo: InsightData;
+    insightInfo: InsightCardInfo;
     /** title of insight card, analysis name and measure name by default 洞察卡片的标题，默认为一个分析类型+分析指标名称 */
     title?: ((defaultTitle?: ReactNode) => ReactNode) | ReactNode;
     /** tools in the header of card, by default, there are no tools 标题右侧的工具栏 */
     headerTools?: Tool[];
     /** tools in the footer of card, by default, there are copy and share tools */
     footerTools?: Tool[];
-    /** configs (algorithms, allData,) used to generate the insight, one of `insightGenerateConfig` and `patterns` must be assigned */
-    insightGenerateConfig?: {
-      algorithms: InsightType[];
+    /** options used to generate the insight, one of `insightGenerateOptions` and `patterns` must be assigned */
+    insightGenerateOptions?: Omit<InsightOptions, 'visualization' | 'dimensions' | 'measures'> & {
       allData: { [x: string]: any }[];
     };
     /** function for customizing content */
     customContentSpecGenerator?: (
-      insightMeta?: InsightData,
+      insightMeta?: InsightCardInfo,
       defaultSpec?: NtvTypes.NarrativeTextSpec
     ) => NtvTypes.NarrativeTextSpec;
     /** custom plugins, should pass if your customized schema includes special plugins ntv schema 中，自己定制的 plugins */

--- a/packages/ava-react/src/InsightCard/types.ts
+++ b/packages/ava-react/src/InsightCard/types.ts
@@ -15,44 +15,44 @@ export type CommonProps = {
  * @description basic info of an insight
  * @description.zh-CN 洞察的基本信息
  */
-export type InsightData = Omit<InsightInfo, 'patterns' | 'visualizationSchemas'> & {
-  /**
-   * unique id of insight, used to identify the insight if you want to find or modify it 洞察的唯一标识，用于需要对洞察识别、修改时能溯源到是哪个洞察
-   */
-  insightId?: string;
+export type InsightData = Omit<InsightInfo, 'score' | 'patterns'> & {
   /**
    * analysis result data, if not defined, will be referred by algorithms. One of `algorithms` and `patterns` must be assigned
-   * 分析得到的洞察数据，`algorithms` 和 `patterns` 至少有一个必须被赋值
+   * 分析得到的洞察数据，`insightGenerateConfig` 和 `patterns` 至少有一个必须被赋值
    */
   patterns?: PatternInfo[];
-  /** algorithms used to generate the insight, one of `algorithms` and `patterns` must be assigned */
-  algorithms?: InsightType[];
-  /** function for customizing content */
-  customContentSpecGenerator?: (
-    insightMeta: InsightInfo,
-    defaultSpec: NtvTypes.NarrativeTextSpec
-  ) => NtvTypes.NarrativeTextSpec;
 };
 
 /** events that may be emitted by card */
 export type InsightCardEventHandlers = {
   /** events emitted when the card content copied */
-  onCopy?: (insight: InsightData, dom?: HTMLElement) => void;
+  onCopy?: (insight?: InsightData, dom?: HTMLElement) => void;
   /** events emitted when the card expose */
-  onCardExpose?: (insight: InsightData, dom?: HTMLElement) => void;
+  onCardExpose?: (insight?: InsightData, dom?: HTMLElement) => void;
   /** events emitted when insight data change */
-  onChange?: (insight?: InsightData) => void;
+  onChange?: (insight?: InsightData, contentSpec?: NtvTypes.NarrativeTextSpec) => void;
 };
 
 export type InsightCardProps = CommonProps &
-  InsightData &
   InsightCardEventHandlers & {
+    /** basic info of an insight */
+    insightInfo: InsightData;
     /** title of insight card, analysis name and measure name by default 洞察卡片的标题，默认为一个分析类型+分析指标名称 */
-    title?: ((defaultTitle: ReactNode) => ReactNode) | ReactNode;
+    title?: ((defaultTitle?: ReactNode) => ReactNode) | ReactNode;
     /** tools in the header of card, by default, there are no tools 标题右侧的工具栏 */
     headerTools?: Tool[];
     /** tools in the footer of card, by default, there are copy and share tools */
     footerTools?: Tool[];
+    /** configs (algorithms, allData,) used to generate the insight, one of `insightGenerateConfig` and `patterns` must be assigned */
+    insightGenerateConfig?: {
+      algorithms: InsightType[];
+      allData: { [x: string]: any }[];
+    };
+    /** function for customizing content */
+    customContentSpecGenerator?: (
+      insightMeta?: InsightData,
+      defaultSpec?: NtvTypes.NarrativeTextSpec
+    ) => NtvTypes.NarrativeTextSpec;
     /** custom plugins, should pass if your customized schema includes special plugins ntv schema 中，自己定制的 plugins */
     extraPlugins?: NtvPluginType[];
   };

--- a/packages/ava-react/src/InsightCard/utils/patternsGenerator.ts
+++ b/packages/ava-react/src/InsightCard/utils/patternsGenerator.ts
@@ -1,1 +1,0 @@
-/** use @ava/insight and insightGenerateConfig to generate patterns */

--- a/packages/ava-react/src/InsightCard/utils/patternsGenerator.ts
+++ b/packages/ava-react/src/InsightCard/utils/patternsGenerator.ts
@@ -1,0 +1,1 @@
+/** use @ava/insight and insightGenerateConfig to generate patterns */

--- a/packages/ava-react/src/InsightCard/utils/specGenerator.ts
+++ b/packages/ava-react/src/InsightCard/utils/specGenerator.ts
@@ -1,24 +1,28 @@
 import { DISPLAY_CHARTS_PLUGIN_KEY } from '../constants';
 
 import type { NtvTypes } from '@antv/ava-react';
-import type { InsightData } from '../types';
+import type { InsightCardInfo } from '../types';
 
 /** generate narrative paragraphs and visualizations for insight data */
-export const generateNarrativeVisSpec = (insightData: InsightData): NtvTypes.NarrativeTextSpec => {
-  const { visualizationSpecs } = insightData;
+export const generateNarrativeVisSpec = (insightInfo: InsightCardInfo): NtvTypes.NarrativeTextSpec => {
+  const { visualizationSpecs } = insightInfo;
   if (visualizationSpecs) {
-    const { narrativeSpec, chartSpec } = visualizationSpecs;
+    const narrativeParagraphs: NtvTypes.ParagraphSpec[] = [];
+    const charts: NtvTypes.ParagraphSpec[] = [];
+    visualizationSpecs.forEach((visualizationSpec) => {
+      const { narrativeSpec, chartSpec } = visualizationSpec;
+      narrativeParagraphs.push(...narrativeSpec);
+      charts.push({
+        type: 'custom',
+        customType: DISPLAY_CHARTS_PLUGIN_KEY,
+        chartSpecs: [chartSpec],
+      });
+    });
+
     const insightContentSpec: NtvTypes.NarrativeTextSpec = {
       sections: [
         {
-          paragraphs: [
-            ...narrativeSpec,
-            {
-              type: 'custom',
-              customType: DISPLAY_CHARTS_PLUGIN_KEY,
-              chartSpecs: [chartSpec],
-            },
-          ],
+          paragraphs: [...narrativeParagraphs, ...charts],
         },
       ],
     };

--- a/packages/ava-react/src/InsightCard/utils/specGenerator.ts
+++ b/packages/ava-react/src/InsightCard/utils/specGenerator.ts
@@ -1,19 +1,29 @@
-import type { G2Spec } from '@antv/g2';
-import type { NtvTypes } from '@antv/ava';
+import { DISPLAY_CHARTS_PLUGIN_KEY } from '../constants';
+
+import type { NtvTypes } from '@antv/ava-react';
 import type { InsightData } from '../types';
 
-// todo
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const generateVisualizationSpec = (insightData: InsightData): G2Spec => {
-  return {};
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const generateNarrativeParagraphs = (insightData: InsightData): NtvTypes.ParagraphSpec[] => {
-  return [];
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/** generate narrative paragraphs and visualizations for insight data */
 export const generateNarrativeVisSpec = (insightData: InsightData): NtvTypes.NarrativeTextSpec => {
+  const { visualizationSpecs } = insightData;
+  if (visualizationSpecs) {
+    const { narrativeSpec, chartSpec } = visualizationSpecs;
+    const insightContentSpec: NtvTypes.NarrativeTextSpec = {
+      sections: [
+        {
+          paragraphs: [
+            ...narrativeSpec,
+            {
+              type: 'custom',
+              customType: DISPLAY_CHARTS_PLUGIN_KEY,
+              chartSpecs: [chartSpec],
+            },
+          ],
+        },
+      ],
+    };
+    return insightContentSpec;
+  }
+  // todo 调用 insight module 中的方法生成 spec
   return {};
 };

--- a/packages/ava-react/src/index.ts
+++ b/packages/ava-react/src/index.ts
@@ -1,1 +1,2 @@
 export * from './NarrativeTextVis';
+export * from './InsightCard';

--- a/playground/package.json
+++ b/playground/package.json
@@ -41,7 +41,6 @@
     "@ant-design/icons": "^4.6.3",
     "@antv/antv-spec": "^0.1.0-alpha.18",
     "@antv/auto-chart": "^2.0.3",
-    "@antv/ava": "^3.0.0-alpha.5",
     "@antv/chart-advisor": "^2.0.3",
     "@antv/ckb": "^2.0.3",
     "@antv/data-wizard": "^2.0.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.3",
-    "@antv/ava": "^3.0.0-alpha.5",
     "@antv/antv-spec": "^0.1.0-alpha.18",
     "@antv/auto-chart": "^2.0.3",
+    "@antv/ava": "^3.0.0-alpha.5",
     "@antv/chart-advisor": "^2.0.3",
     "@antv/ckb": "^2.0.3",
     "@antv/data-wizard": "^2.0.3",
@@ -51,6 +51,7 @@
     "@antv/lite-insight": "^2.0.3",
     "@antv/narrative-text-vis": "^0.3.6",
     "@antv/s2": "^1.0.0-beta.9",
+    "@antv/s2-react": "^1.37.1",
     "@antv/smart-board": "^2.0.3",
     "@antv/smart-color": "^0.2.1",
     "@antv/thumbnails": "^2.0.0",

--- a/playground/src/DevPlayground/LiteInsight/AutoInsight.tsx
+++ b/playground/src/DevPlayground/LiteInsight/AutoInsight.tsx
@@ -151,7 +151,7 @@ export default function App() {
             {insights.map((insightInfo, index) => {
               const insightCardProps = {
                 insightInfo,
-                customContentSpecGenerator: () => {
+                customContentSpec: () => {
                   return customInsightCardContentSpec;
                 },
               };

--- a/playground/src/DevPlayground/LiteInsight/AutoInsight.tsx
+++ b/playground/src/DevPlayground/LiteInsight/AutoInsight.tsx
@@ -4,9 +4,11 @@ import { Select, Button, Table, Row, Col, Form, Switch } from 'antd';
 import { GiftOutlined } from '@ant-design/icons';
 // @ts-ignore
 import datasets from 'vega-datasets';
-import { InsightCard } from 'antv-site-demo-rc';
 
+import { InsightCard } from '../../../../packages/ava-react/src';
 import { getInsights, InsightTypes } from '../../../../packages/ava/lib';
+
+import { customInsightCardContentSpec } from './mockSpec';
 
 const { Option } = Select;
 
@@ -69,15 +71,15 @@ const datasetConfigs = {
 
 export default function App() {
   const [insights, setInsights] = useState<InsightTypes.InsightInfo<InsightTypes.PatternInfo>[]>([]);
-  const [dataset, setDataset] = useState('gapminder');
+  const [dataset, setDataset] = useState<keyof typeof datasetConfigs>('gapminder');
   const [data, setData] = useState<InsightTypes.Datum[]>([]);
   const [tableColumns, setTableColumns] = useState<InsightTypes.Datum[]>([]);
   const [dataLoading, setDataLoading] = useState<boolean>(false);
   const [insightLoading, setInsightLoading] = useState<boolean>(false);
-  const [showTextSchema, setShowTextSchema] = useState<boolean>(false);
+  const [showTextSchema, setShowTextSchema] = useState<boolean>(true);
 
   const fetchDataset = async () => {
-    const datasetName = `${dataset}.json`;
+    const datasetName = `${dataset}.json` as keyof typeof datasets;
     setDataLoading(true);
     const data = await datasets[datasetName]();
     if (data) {
@@ -118,7 +120,7 @@ export default function App() {
                 loading={insightLoading}
                 value={dataset}
                 style={{ width: 120, marginLeft: 12 }}
-                onChange={(v) => setDataset(v as string)}
+                onChange={(v) => setDataset(v)}
               >
                 {datasetOptions.map((item) => (
                   <Option value={item} key={item}>
@@ -145,9 +147,21 @@ export default function App() {
               </Form.Item>
             </Col>
           </Row>
-          {insights.map((item, index) => (
-            <InsightCard key={index} insightInfo={item as any} height={400} />
-          ))}
+          <Row justify="space-around">
+            {insights.map((insightInfo, index) => {
+              const insightCardProps = {
+                insightInfo,
+                customContentSpecGenerator: () => {
+                  return customInsightCardContentSpec;
+                },
+              };
+              return (
+                <Col key={index}>
+                  <InsightCard {...insightCardProps} styles={{ width: 400 }} />
+                </Col>
+              );
+            })}
+          </Row>
         </div>
       )}
     </>

--- a/playground/src/DevPlayground/LiteInsight/mockSpec.ts
+++ b/playground/src/DevPlayground/LiteInsight/mockSpec.ts
@@ -1,0 +1,261 @@
+export const timeSeriesChartSpec = {
+  type: 'view',
+  theme: 'classic',
+  axis: {
+    x: {
+      labelAutoHide: true,
+      labelAutoRotate: false,
+      title: false,
+    },
+    y: {
+      title: false,
+    },
+  },
+  scale: {
+    y: {
+      nice: true,
+    },
+  },
+  interaction: {
+    tooltip: {
+      groupName: false,
+    },
+  },
+  legend: false,
+  children: [
+    {
+      data: [
+        {
+          date: '2019-08-12',
+          discountPrice: 781.99,
+        },
+        {
+          date: '2019-08-13',
+          discountPrice: 835.71,
+        },
+        {
+          date: '2019-08-14',
+          discountPrice: 839.24,
+        },
+        {
+          date: '2019-08-15',
+          discountPrice: 883.51,
+        },
+        {
+          date: '2019-08-16',
+          discountPrice: 873.98,
+        },
+        {
+          date: '2019-08-17',
+          discountPrice: 802.78,
+        },
+        {
+          date: '2019-08-18',
+          discountPrice: 807.05,
+        },
+        {
+          date: '2019-08-19',
+          discountPrice: 885.12,
+        },
+        {
+          date: '2019-08-20',
+          discountPrice: 1018.85,
+        },
+        {
+          date: '2019-08-21',
+          discountPrice: 934.49,
+        },
+        {
+          date: '2019-08-22',
+          discountPrice: 908.74,
+        },
+        {
+          date: '2019-08-23',
+          discountPrice: 930.55,
+        },
+        {
+          date: '2019-08-24',
+          discountPrice: 978.53,
+        },
+        {
+          date: '2019-08-25',
+          discountPrice: 931.47,
+        },
+        {
+          date: '2019-08-26',
+          discountPrice: 891,
+        },
+        {
+          date: '2019-08-27',
+          discountPrice: 836.41,
+        },
+      ],
+      encode: {
+        x: 'date',
+        y: 'discountPrice',
+      },
+      type: 'line',
+      key: '0-0',
+    },
+    {
+      style: {
+        stroke: '#ffa45c',
+        lineWidth: 1,
+      },
+      tooltip: {
+        title: '',
+        items: [
+          {
+            name: 'baseline',
+            channel: 'y',
+          },
+        ],
+      },
+      type: 'line',
+      data: [
+        ['2019-08-12', 813.1986098231948],
+        ['2019-08-13', 823.1190264225548],
+        ['2019-08-14', 832.8341808698422],
+        ['2019-08-15', 842.7607694087598],
+        ['2019-08-16', 853.2501986376163],
+        ['2019-08-17', 863.8170969240749],
+        ['2019-08-18', 874.6156613441703],
+        ['2019-08-19', 883.7838645419531],
+        ['2019-08-20', 893.9900171430626],
+        ['2019-08-21', 906.5749342676551],
+        ['2019-08-22', 918.0016062325483],
+        ['2019-08-23', 916.0148272896506],
+        ['2019-08-24', 911.6068918597696],
+        ['2019-08-25', 906.0625598784213],
+        ['2019-08-26', 899.3923860434285],
+        ['2019-08-27', 891.3209163060191],
+      ],
+      encode: { x: (d) => d[0], y: (d) => d[1] },
+      key: '0-1',
+    },
+    {
+      style: {
+        fillOpacity: 0.3,
+        fill: '#ffd8b8',
+      },
+      type: 'area',
+      data: [
+        ['2019-08-12', [722.6189603630733, 910.2044041824067]],
+        ['2019-08-13', [732.5393769624333, 920.1248207817667]],
+        ['2019-08-14', [742.2545314097206, 929.8399752290541]],
+        ['2019-08-15', [752.1811199486382, 939.7665637679717]],
+        ['2019-08-16', [762.6705491774948, 950.2559929968282]],
+        ['2019-08-17', [773.2374474639533, 960.8228912832868]],
+        ['2019-08-18', [784.0360118840488, 971.6214557033823]],
+        ['2019-08-19', [793.2042150818315, 980.789658901165]],
+        ['2019-08-20', [803.410367682941, 990.9958115022745]],
+        ['2019-08-21', [815.9952848075335, 1003.580728626867]],
+        ['2019-08-22', [827.4219567724267, 1015.0074005917602]],
+        ['2019-08-23', [825.435177829529, 1013.0206216488625]],
+        ['2019-08-24', [821.027242399648, 1008.6126862189815]],
+        ['2019-08-25', [815.4829104182998, 1003.0683542376332]],
+        ['2019-08-26', [808.8127365833069, 996.3981804026404]],
+        ['2019-08-27', [800.7412668458975, 988.326710665231]],
+      ],
+      encode: { x: (d) => d[0], y: (d) => [d[1][0], d[1][1]] },
+      key: '0-2',
+    },
+    {
+      type: 'point',
+      data: [['2019-08-20', 1018.85]],
+      encode: { x: (d) => d[0], y: (d) => d[1] },
+      style: {
+        fill: '#f4664a',
+        stroke: '#f4664a',
+      },
+      tooltip: {
+        title: '',
+        items: [
+          {
+            name: 'outlier',
+            channel: 'y',
+          },
+        ],
+      },
+      key: '0-3',
+    },
+  ],
+};
+
+export const customNarrativeSpec = [
+  {
+    type: 'normal',
+    phrases: [
+      {
+        type: 'entity',
+        value: 'pop',
+        metadata: {
+          entityType: 'metric_name',
+        },
+      },
+      {
+        type: 'text',
+        value: ' has ',
+      },
+      {
+        type: 'entity',
+        value: '2',
+        metadata: {
+          entityType: 'metric_value',
+          origin: 2,
+        },
+      },
+      {
+        type: 'text',
+        value: ' categories in the ',
+      },
+      {
+        type: 'text',
+        value: 'country',
+      },
+      {
+        type: 'text',
+        value: ' that are prominent compared to other dimensions: ',
+      },
+      {
+        type: 'entity',
+        value: 'China',
+        metadata: {
+          entityType: 'dim_value',
+        },
+      },
+      {
+        type: 'text',
+        value: ',',
+      },
+      {
+        type: 'entity',
+        value: 'India',
+        metadata: {
+          entityType: 'dim_value',
+        },
+      },
+      {
+        type: 'text',
+        value: '.',
+      },
+    ],
+  },
+];
+
+export const customChartSpecs = [timeSeriesChartSpec];
+
+export const customInsightCardContentSpec = {
+  sections: [
+    {
+      paragraphs: [
+        ...customNarrativeSpec,
+        {
+          type: 'custom',
+          customType: 'charts',
+          chartSpecs: customChartSpecs,
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
- adjust insight card api: group props of insight data as `insightInfo`
- support generate spec using `visualizationSpec` insight info 
- support render custom spec in insight card

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos
