### PR TITLE
feat(ava/insight): format y axis label by default

### DIFF
--- a/packages/ava/src/insight/chart/strategy/viewSpec.ts
+++ b/packages/ava/src/insight/chart/strategy/viewSpec.ts
@@ -1,12 +1,14 @@
 import { G2Spec, Mark } from '@antv/g2';
 
+import { dataFormat } from '../../../utils';
+
 export const viewSpecStrategy = (marks: Mark[]): G2Spec => {
   return {
     type: 'view',
     theme: 'classic',
     axis: {
       x: { labelAutoHide: true, labelAutoRotate: false, title: false },
-      y: { title: false },
+      y: { title: false, labelFormatter: (d) => dataFormat(d) },
     },
     scale: {
       y: { nice: true },


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
RT
before:
![image](https://user-images.githubusercontent.com/16997933/226539687-16d39ee3-ea9b-4ac4-bdbe-8220d39a5e5b.png)

after:
<img width="468" alt="截屏2023-03-21 下午3 15 17" src="https://user-images.githubusercontent.com/16997933/226539639-2b9f0ec8-e814-4bcf-b422-b33a6183033c.png">

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos
