### PR TITLE
feat(ava-react/insight-card): support copy insight result & canvas size change

### DIFF
--- a/packages/ava-react/src/InsightCard/Toolbar/constants.ts
+++ b/packages/ava-react/src/InsightCard/Toolbar/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_TOOLS = ['copy', 'export'] as const;
+export const DEFAULT_TOOLS = ['copy', 'others'] as const;

--- a/packages/ava-react/src/InsightCard/Toolbar/defaultTools.tsx
+++ b/packages/ava-react/src/InsightCard/Toolbar/defaultTools.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { CopyOutlined, ExportOutlined } from '@ant-design/icons';
-import { Button, Tooltip } from 'antd';
+import { CopyOutlined, MoreOutlined } from '@ant-design/icons';
+import { Button, Tooltip, Dropdown } from 'antd';
 
 import { INSIGHT_CARD_PREFIX_CLS } from '../constants';
 import { IconButton } from '../styled/iconButton';
 
 import type { BaseIconButtonProps, DefaultToolType } from './types';
+import type { DropdownProps } from 'antd';
 
 export const BaseIconButton: React.FC<BaseIconButtonProps> = ({ icon, onClick, description }) => {
   return (
@@ -37,18 +38,23 @@ const defaultCopyButton = () => {
   };
 };
 
-const defaultExportButton = () => {
+export const defaultMoreButton = (props: DropdownProps['menu'] = {}) => {
+  const { items, onClick } = props;
   return {
-    type: 'export',
-    description: 'export',
-    icon: <ExportOutlined />,
+    type: 'others',
+    description: '',
+    icon: (
+      <Dropdown menu={{ items, onClick }}>
+        <MoreOutlined />
+      </Dropdown>
+    ),
   };
 };
 
 export const getDefaultTool = (type: DefaultToolType) => {
   const toolsFunctionMap = {
     copy: defaultCopyButton,
-    export: defaultExportButton,
+    others: defaultMoreButton,
   };
   return toolsFunctionMap[type]?.();
 };

--- a/packages/ava-react/src/InsightCard/constants.tsx
+++ b/packages/ava-react/src/InsightCard/constants.tsx
@@ -20,3 +20,14 @@ export const CARD_CONTENT_HEIGHT = 48;
 export const CHART_HEIGHT = 280;
 /** chart carousel plugin key  */
 export const DISPLAY_CHARTS_PLUGIN_KEY = 'charts';
+
+export const EXPORT_DATA_LABEL = {
+  'zh-CN': {
+    insightInfo: '复制洞察结果',
+    spec: '复制可视化 schema',
+  },
+  'en-US': {
+    insightInfo: 'copy insight result data',
+    spec: 'copy visualization spec',
+  },
+};

--- a/packages/ava-react/src/InsightCard/index.ts
+++ b/packages/ava-react/src/InsightCard/index.ts
@@ -1,3 +1,3 @@
-export type { ToolbarProps as InsightCardToolBarProps } from './Toolbar/types';
 export { InsightCard } from './InsightCard';
-export { InsightCardProps } from './types';
+export type { ToolbarProps as InsightCardToolBarProps } from './Toolbar/types';
+export type { InsightCardProps } from './types';

--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
@@ -7,7 +7,6 @@ import { INSIGHT_CARD_PREFIX_CLS } from '../../constants';
 export const G2Chart = ({ spec, height, width }: { spec: G2Spec; height?: number; width?: number }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = React.useRef<Chart>(null);
-
   useEffect(() => {
     if (!chartRef?.current) {
       chartRef.current = new Chart({ container: containerRef?.current, autoFit: true });
@@ -25,6 +24,20 @@ export const G2Chart = ({ spec, height, width }: { spec: G2Spec; height?: number
     }
     chartRef.current.render();
   }, [spec]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      chartRef.current?.options({
+        width: containerRef.current?.clientWidth,
+        height: containerRef.current?.clientHeight,
+      });
+      chartRef.current?.render();
+    };
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(containerRef.current);
+
+    return () => resizeObserver.disconnect();
+  }, []);
 
   return (
     <div className={`${INSIGHT_CARD_PREFIX_CLS}-chart-container`}>


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
- support copy insight content and spec 卡片上支持复制能力
- support g2 canvas size change according to container size 支持卡片中图表画布大小响应容器变化
