### PR TITLE
fix(ava-react/insight-card): fix g2 chart render

### DIFF
--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
@@ -7,37 +7,30 @@ import { INSIGHT_CARD_PREFIX_CLS } from '../../constants';
 export const G2Chart = ({ spec, height, width }: { spec: G2Spec; height?: number; width?: number }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = React.useRef<Chart>(null);
-  useEffect(() => {
+  const isRendering = React.useRef(false);
+
+  const renderChart = async () => {
     if (!chartRef?.current) {
-      chartRef.current = new Chart({ container: containerRef?.current, autoFit: true });
-      chartRef.current.options({
-        width: containerRef.current?.clientWidth,
-        height: containerRef.current?.clientHeight,
-        ...spec,
+      chartRef.current = new Chart({
+        container: containerRef?.current,
+        autoFit: true,
+        paddingLeft: 'auto',
       });
+      chartRef.current.options(spec);
     } else {
-      chartRef.current.options({
-        width: containerRef.current?.clientWidth,
-        height: containerRef.current?.clientHeight,
-        ...spec,
-      });
+      chartRef.current.options(spec);
     }
-    chartRef.current.render();
-  }, [spec]);
+
+    if (!isRendering.current) {
+      isRendering.current = true;
+      await chartRef.current?.render();
+      isRendering.current = false;
+    }
+  };
 
   useEffect(() => {
-    const handleResize = () => {
-      chartRef.current?.options({
-        width: containerRef.current?.clientWidth,
-        height: containerRef.current?.clientHeight,
-      });
-      chartRef.current?.render();
-    };
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(containerRef.current);
-
-    return () => resizeObserver.disconnect();
-  }, []);
+    renderChart();
+  }, [spec]);
 
   return (
     <div className={`${INSIGHT_CARD_PREFIX_CLS}-chart-container`}>


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #681 

更新 G2 后，调用 `chart.render()` 时，如果第一次 render 没有结束就调用了第二次，会渲染错误
- 之前由于 G2 不支持 auto size, 在容器大小改变时，重新 render，导致了初始化时多次 render 。去掉这部分逻辑后可以正常展示
- stric mode 下 useEffect 会被执行两次 因此加一个 isRendering 状态，限制渲染中不能更新
