### PR TITLE
fix(avar-react/insight-card): Add miss dependency when generate contentSpec

### DIFF
--- a/packages/ava-react/src/InsightCard/InsightCard.tsx
+++ b/packages/ava-react/src/InsightCard/InsightCard.tsx
@@ -81,7 +81,7 @@ export const InsightCard: React.FC<InsightCardProps> = ({
       ? customContentSpec?.(currentInsightInfo, defaultSpec)
       : customContentSpec;
     return customSpec ?? defaultSpec;
-  }, [currentInsightInfo]);
+  }, [currentInsightInfo, customContentSpec]);
 
   useEffect(() => {
     onCardExpose?.(currentInsightInfo, ref.current);


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed 生成 spec 中的 useMemo 缺少依赖  customContentSpec
- [ ] add / modify test cases
- [ ] documents, demos
