### PR TITLE
fix(ava-react/insight-card): fix insight content & chart not update correctly

### DIFF
--- a/packages/ava-react/src/InsightCard/InsightCard.tsx
+++ b/packages/ava-react/src/InsightCard/InsightCard.tsx
@@ -59,12 +59,10 @@ export const InsightCard: React.FC<InsightCardProps> = ({
 
   useEffect(() => {
     // if patterns or visualizationSpecs is not empty, do not need generate insight patterns
-    if (defaultInsightInfo?.patterns) {
-      setCurrentInsightInfo(defaultInsightInfo);
-      return;
-    }
+    setCurrentInsightInfo(defaultInsightInfo);
+
     // if patterns and visualizationSpecs are empty, use autoInsightOptions to generate insight patterns
-    if (autoInsightOptions) {
+    if (!defaultInsightInfo?.patterns && autoInsightOptions) {
       calculateAndSetInsightPatterns();
     }
   }, [defaultInsightInfo, autoInsightOptions]);

--- a/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
+++ b/packages/ava-react/src/InsightCard/ntvPlugins/components/G2Chart.tsx
@@ -14,10 +14,15 @@ export const G2Chart = ({ spec, height, width }: { spec: G2Spec; height?: number
       chartRef.current = new Chart({
         container: containerRef?.current,
         autoFit: true,
-        paddingLeft: 'auto',
+        padding: 'auto',
       });
       chartRef.current.options(spec);
     } else {
+      chartRef.current.clear();
+      chartRef.current.options({
+        autoFit: true,
+        padding: 'auto',
+      });
       chartRef.current.options(spec);
     }
 

--- a/packages/ava-react/src/InsightCard/types.ts
+++ b/packages/ava-react/src/InsightCard/types.ts
@@ -42,7 +42,7 @@ export type InsightCardProps = CommonProps &
     headerTools?: Tool[];
     /** tools in the footer of card, by default, there are copy and share tools */
     footerTools?: Tool[];
-    /** [Note: this property is experimental and might be adjusted in the future version]. Options used to generate the insight, one of `autoInsightOptions` and `insightInfo` must be assigned */
+    /** [Note: this property is experimental and might be adjusted in the future version]. Options used to generate the insight, one of `autoInsightOptions` and `insightInfo` must be assigned. `insightInfo` will override auto-generated insights  */
     autoInsightOptions?: Omit<InsightOptions, 'visualization'> & {
       allData: { [x: string]: any }[];
     };


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #709 

1.insight content  should be updated whether the insight info is empty or not
2.when using `chart.options` to update spec, the new spec will be merged into the old one, but in InsightCard, the new spec should override the old one, so  the `clear` method should be called before update
before:
<img width="265" alt="截屏2023-06-20 下午1 38 51" src="https://github.com/antvis/AVA/assets/16997933/9d249b2b-b16c-43fa-9dd0-a4d4f9f2d0bf">
after: 
<img width="153" alt="截屏2023-06-20 下午1 39 26" src="https://github.com/antvis/AVA/assets/16997933/887c79ca-d1ac-48a7-850b-61bf4ab5ac4c">
