### PR TITLE
fix(ava/insight): fix time range of change point in narrative strategy

### DIFF
--- a/packages/ava/src/insight/narrative/strategy/changePoint.ts
+++ b/packages/ava/src/insight/narrative/strategy/changePoint.ts
@@ -39,11 +39,12 @@ export default class ChangePointNarrativeStrategy extends InsightNarrativeStrate
   };
 
   generateTextSpec(insightInfo: InsightInfo<ChangePointInfo>, lang: Language) {
-    const { patterns } = insightInfo;
+    const { patterns, data } = insightInfo;
+    const { dimension } = patterns[0];
     const spec = generateTextSpec({
       structures: ChangePointNarrativeStrategy.structures[lang],
       variable: {
-        dateRange: `${first(patterns).x}~${last(patterns).x}`,
+        dateRange: `${first(data)[dimension]}~${last(data)[dimension]}`,
         measure: patterns[0].measure,
         total: patterns.length,
       },


### PR DESCRIPTION
the origin time range is:
<img width="537" alt="image" src="https://github.com/antvis/AVA/assets/61140088/81b4427b-c618-4bf6-b8bb-326a19bae09c">
after fix:
<img width="537" alt="image" src="https://github.com/antvis/AVA/assets/61140088/306474e0-9130-4453-95a7-03ab537a3fda">

