### PR TITLE
fix(ava,ava-react): ntv text phrase support start space of line

### DIFF
--- a/packages/ava-react/package.json
+++ b/packages/ava-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/ava-react",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "React components of AVA.",
   "author": {
     "name": "AntV",

--- a/packages/ava-react/src/NarrativeTextVis/styled/paragraph.tsx
+++ b/packages/ava-react/src/NarrativeTextVis/styled/paragraph.tsx
@@ -6,6 +6,7 @@ import type { TextParagraphSpec } from '@antv/ava';
 import type { ThemeStylesProps } from '../types';
 
 export const P = styled.p<ThemeStylesProps & Pick<TextParagraphSpec, 'indents'>>`
+  white-space: pre-wrap; // 默认 pre 显示，可以显示空格和转义字符
   font-family: PingFangSC, sans-serif;
   color: ${({ theme }) => getThemeColor('colorBase', theme)};
   font-size: ${({ size }) => getFontSize(size)};

--- a/packages/ava/src/ntv/schema/phrase.ts
+++ b/packages/ava/src/ntv/schema/phrase.ts
@@ -22,6 +22,7 @@ export type TextPhraseSpec = CommonProps & {
 /**
  * escape character 支持转义字符
  */
+// @deprecated 通过 white-space: pre; 可以让普通文本也具有转义字符大部分效果，之后版本可以考虑去掉
 export type EscapePhraseSpec = CommonProps & {
   type: 'escape';
   value: string;

--- a/playground/src/DevPlayground/NTV/index.tsx
+++ b/playground/src/DevPlayground/NTV/index.tsx
@@ -348,7 +348,7 @@ const App = () => {
                   phrases: [
                     {
                       type: 'text',
-                      value: '在 text 中的转义字符字符 \r\n 无效，后面是 escape 类型短语，换行：',
+                      value: '通过 escape 类型短语换行：',
                     },
                     {
                       type: 'escape',
@@ -356,7 +356,7 @@ const App = () => {
                     },
                     {
                       type: 'text',
-                      value: '回车',
+                      value: '回车：',
                     },
                     {
                       type: 'escape',

--- a/site/examples/ntv/basic/demo/extra-phrases.tsx
+++ b/site/examples/ntv/basic/demo/extra-phrases.tsx
@@ -17,7 +17,7 @@ const spec: NarrativeTextSpec = {
           phrases: [
             {
               type: 'text',
-              value: '在 text 中的转义字符字符 \r\n 无效，后面是 escape 类型短语，换行：',
+              value: '通过 escape 类型短语换行：',
             },
             {
               type: 'escape',
@@ -25,7 +25,7 @@ const spec: NarrativeTextSpec = {
             },
             {
               type: 'text',
-              value: '回车',
+              value: '回车：',
             },
             {
               type: 'escape',


### PR DESCRIPTION
### PR includes
![image](https://github.com/antvis/AVA/assets/35586469/b6dfb353-6b5a-4aa0-9460-d76af1f2b96a)

- [ ] fixed #0
- [ ] add / modify test cases
- [x] documents, demos
