### PR TITLE
feat(ava/insight): support calling algorithms individually

### DIFF
--- a/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/categoryOutlier';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,15 @@ const data = [
 
 describe('extract category-outlier insight', () => {
   test('check outliers result', () => {
-    const result = extractor({ data, dimensions: ['type'], measures: [{ fieldName: 'sales', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['type'],
+      measures: [{ fieldName: 'sales', method: 'SUM' }],
+      insightType: 'category_outlier',
+      options: {
+        filterInsight: true,
+      },
+    });
     const outlierIndexes = result?.map((item) => item.index);
     expect(outlierIndexes).toStrictEqual([3]);
   });

--- a/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,7 @@ const data = [
 
 describe('extract category-outlier insight', () => {
   test('check outliers result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['type'],
       measures: [{ fieldName: 'sales', method: 'SUM' }],

--- a/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 0.3 },
@@ -14,7 +14,7 @@ const data = [
 
 describe('extract change-point insight', () => {
   test('check change-point result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['year'],
       measures: [{ fieldName: 'value', method: 'SUM' }],

--- a/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/changePoint';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 0.3 },
@@ -14,7 +14,15 @@ const data = [
 
 describe('extract change-point insight', () => {
   test('check change-point result', () => {
-    const result = extractor({ data, dimensions: ['year'], measures: [{ fieldName: 'value', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['year'],
+      measures: [{ fieldName: 'value', method: 'SUM' }],
+      insightType: 'change_point',
+      options: {
+        filterInsight: true,
+      },
+    });
     expect(result[0]?.index).toEqual(5);
   });
 });

--- a/packages/ava/__tests__/unit/insight/extractors/correlation.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/correlation.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/correlation';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { x: 1, y: 4.181 },
@@ -36,13 +36,17 @@ const data = [
 
 describe('extract correlation insight', () => {
   test('check correlation result', () => {
-    const result = extractor({
+    const result = insightExtractor({
       data,
       dimensions: [],
       measures: [
         { fieldName: 'x', method: 'SUM' },
         { fieldName: 'y', method: 'SUM' },
       ],
+      insightType: 'correlation',
+      options: {
+        filterInsight: true,
+      },
     });
     expect(result[0]?.pcorr).toBeGreaterThan(0.8);
   });

--- a/packages/ava/__tests__/unit/insight/extractors/correlation.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/correlation.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { x: 1, y: 4.181 },
@@ -36,7 +36,7 @@ const data = [
 
 describe('extract correlation insight', () => {
   test('check correlation result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: [],
       measures: [

--- a/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,7 @@ const data = [
 
 describe('extract low-variance insight', () => {
   test('check low-variance result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['type'],
       measures: [{ fieldName: 'sales', method: 'SUM' }],

--- a/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/lowVariance';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,15 @@ const data = [
 
 describe('extract low-variance insight', () => {
   test('check low-variance result', () => {
-    const result = extractor({ data, dimensions: ['type'], measures: [{ fieldName: 'sales', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['type'],
+      measures: [{ fieldName: 'sales', method: 'SUM' }],
+      insightType: 'low_variance',
+      options: {
+        filterInsight: true,
+      },
+    });
     expect(result[0]?.significance).toBeGreaterThan(0.85);
   });
 });

--- a/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/majority';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,15 @@ const data = [
 
 describe('extract majority insight', () => {
   test('check majority result', () => {
-    const result = extractor({ data, dimensions: ['type'], measures: [{ fieldName: 'sales', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['type'],
+      measures: [{ fieldName: 'sales', method: 'SUM' }],
+      insightType: 'majority',
+      options: {
+        filterInsight: true,
+      },
+    });
     expect(result[0]?.index).toEqual(5);
   });
 });

--- a/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   {
@@ -37,7 +37,7 @@ const data = [
 
 describe('extract majority insight', () => {
   test('check majority result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['type'],
       measures: [{ fieldName: 'sales', method: 'SUM' }],

--- a/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 3 },
@@ -14,7 +14,7 @@ const data = [
 
 describe('extract time-series-outlier insight', () => {
   test('check outliers result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['year'],
       measures: [{ fieldName: 'value', method: 'SUM' }],

--- a/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/timeSeriesOutlier';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 3 },
@@ -14,7 +14,15 @@ const data = [
 
 describe('extract time-series-outlier insight', () => {
   test('check outliers result', () => {
-    const result = extractor({ data, dimensions: ['year'], measures: [{ fieldName: 'value', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['year'],
+      measures: [{ fieldName: 'value', method: 'SUM' }],
+      insightType: 'time_series_outlier',
+      options: {
+        filterInsight: true,
+      },
+    });
     const outliers = result?.map((item) => item.index);
     expect(outliers).toStrictEqual([7]);
   });

--- a/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
@@ -1,4 +1,4 @@
-import { extractor } from '../../../../src/insight/insights/extractors/trend';
+import { insightExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 3 },
@@ -14,7 +14,15 @@ const data = [
 
 describe('extract trend insight', () => {
   test('check trend result', () => {
-    const result = extractor({ data, dimensions: ['year'], measures: [{ fieldName: 'value', method: 'SUM' }] });
+    const result = insightExtractor({
+      data,
+      dimensions: ['year'],
+      measures: [{ fieldName: 'value', method: 'SUM' }],
+      insightType: 'trend',
+      options: {
+        filterInsight: true,
+      },
+    });
     expect(result[0]?.trend).toEqual('increasing');
   });
 });

--- a/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
@@ -1,4 +1,4 @@
-import { insightExtractor } from '../../../../src/insight/insights';
+import { insightPatternsExtractor } from '../../../../src/insight/insights';
 
 const data = [
   { year: '1991', value: 3 },
@@ -14,7 +14,7 @@ const data = [
 
 describe('extract trend insight', () => {
   test('check trend result', () => {
-    const result = insightExtractor({
+    const result = insightPatternsExtractor({
       data,
       dimensions: ['year'],
       measures: [{ fieldName: 'value', method: 'SUM' }],

--- a/packages/ava/src/data/statistics/constants.ts
+++ b/packages/ava/src/data/statistics/constants.ts
@@ -1,4 +1,4 @@
-import { LowessOptions, PCorrTestOptions } from './types';
+import { LowessOptions, PCorrTestParameter } from './types';
 
 /** default options in LOWESS */
 export const DEFAULT_LOWESS_OPTIONS: LowessOptions = {
@@ -8,7 +8,7 @@ export const DEFAULT_LOWESS_OPTIONS: LowessOptions = {
 };
 
 /** default options in LOWESS */
-export const DEFAULT_PCORRTEST_OPTIONS: PCorrTestOptions = {
+export const DEFAULT_PCORRTEST_OPTIONS: PCorrTestParameter = {
   alpha: 0.05,
   alternative: 'two-sided',
   rho: 0,

--- a/packages/ava/src/data/statistics/pcorrtest.ts
+++ b/packages/ava/src/data/statistics/pcorrtest.ts
@@ -3,10 +3,10 @@ import { mergeWith } from 'lodash';
 import { pearson } from './base';
 import { DEFAULT_PCORRTEST_OPTIONS } from './constants';
 import { normalDistributionQuantile, tDistributionQuantile } from './quantile';
-import { PCorrTestOptions, PCorrTestOutput } from './types';
+import { PCorrTestParameter, PCorrTestOutput } from './types';
 
 /** Perform a Pearson product-moment correlation test between paired samples  */
-export const pcorrtest = (x: number[], y: number[], options?: PCorrTestOptions): PCorrTestOutput => {
+export const pcorrtest = (x: number[], y: number[], options?: PCorrTestParameter): PCorrTestOutput => {
   if (x.length !== y.length) {
     // eslint-disable-next-line no-console
     console.error('invalid arguments: First and second arguments must be arrays having the same length');

--- a/packages/ava/src/data/statistics/types.ts
+++ b/packages/ava/src/data/statistics/types.ts
@@ -25,7 +25,7 @@ export type LowessOutput = {
   y: number[];
 };
 
-export type PCorrTestOptions = {
+export type PCorrTestParameter = {
   /**
    * Significance level (default: 0.05).
    */

--- a/packages/ava/src/insight/constant.ts
+++ b/packages/ava/src/insight/constant.ts
@@ -25,6 +25,6 @@ export const PATTERN_TYPES = [
 
 export const HOMOGENEOUS_PATTERN_TYPES = ['commonness', 'exception'] as const;
 
-export const VERIFICATION_FAILURE_INFO = 'The data does not meet the requirements.';
+export const VERIFICATION_FAILURE_INFO = 'The input does not meet the requirements.';
 
 export const NO_PATTERN_INFO = 'No insights were found at the specified significance threshold.';

--- a/packages/ava/src/insight/constant.ts
+++ b/packages/ava/src/insight/constant.ts
@@ -28,3 +28,5 @@ export const HOMOGENEOUS_PATTERN_TYPES = ['commonness', 'exception'] as const;
 export const VERIFICATION_FAILURE_INFO = 'The input does not meet the requirements.';
 
 export const NO_PATTERN_INFO = 'No insights were found at the specified significance threshold.';
+
+export const CHANGE_POINT_SIGNIFICANCE_BENCHMARK = 0.15;

--- a/packages/ava/src/insight/constant.ts
+++ b/packages/ava/src/insight/constant.ts
@@ -24,3 +24,7 @@ export const PATTERN_TYPES = [
 ] as const;
 
 export const HOMOGENEOUS_PATTERN_TYPES = ['commonness', 'exception'] as const;
+
+export const VERIFICATION_FAILURE_INFO = 'The data does not meet the requirements.';
+
+export const NO_PATTERN_INFO = 'No insights were found at the specified significance threshold.';

--- a/packages/ava/src/insight/insights/checkers.ts
+++ b/packages/ava/src/insight/insights/checkers.ts
@@ -5,12 +5,12 @@ import { NumberFieldInfo } from '../../data';
 
 import type { LevelOfMeasurement } from '../../ckb';
 
-export type ExtractorChecker = (
-  data: Datum[],
-  subjectInfo: SubjectInfo,
-  fieldPropsMap: Record<string, DataProperty>,
-  lom?: LevelOfMeasurement | LevelOfMeasurement[]
-) => boolean;
+export type ExtractorChecker = (props: {
+  data: Datum[];
+  subjectInfo: SubjectInfo;
+  fieldPropsMap: Record<string, DataProperty>;
+  lom?: LevelOfMeasurement | LevelOfMeasurement[];
+}) => boolean;
 
 const fieldsQuantityChecker = (subjectInfo: SubjectInfo, dimensionsQuantity: number, measuresQuantity: number) => {
   const { dimensions, measures } = subjectInfo;
@@ -18,7 +18,7 @@ const fieldsQuantityChecker = (subjectInfo: SubjectInfo, dimensionsQuantity: num
   return false;
 };
 
-const generalCheckerFor1M1D: ExtractorChecker = (data, subjectInfo, fieldPropsMap, lom) => {
+const generalCheckerFor1M1D: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap, lom }) => {
   const { dimensions } = subjectInfo;
   // check data length
   if (data?.length < 3) return false;
@@ -34,32 +34,33 @@ const generalCheckerFor1M1D: ExtractorChecker = (data, subjectInfo, fieldPropsMa
   return true;
 };
 
-export const trendChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  return generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, 'Time');
+export const trendChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  return generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: 'Time' });
 };
 
-export const categoryOutlierChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  return generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, ['Nominal', 'Discrete', 'Ordinal']);
+export const categoryOutlierChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  return generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: ['Nominal', 'Discrete', 'Ordinal'] });
 };
 
-export const changePointChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  return generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, 'Time');
+export const changePointChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  return generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: 'Time' });
 };
 
-export const timeSeriesChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  return generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, 'Time');
+export const timeSeriesChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  return generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: 'Time' });
 };
 
-export const majorityChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  if (!generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, ['Nominal', 'Discrete', 'Ordinal', 'Time']))
+export const majorityChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  if (!generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: ['Nominal', 'Discrete', 'Ordinal', 'Time'] }))
     return false;
   const { measures } = subjectInfo;
   if (!['count', 'sum'].includes(measures[0].method)) return false;
   return true;
 };
 
-export const lowVarianceChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
-  if (!generalCheckerFor1M1D(data, subjectInfo, fieldPropsMap, ['Nominal', 'Discrete', 'Ordinal'])) return false;
+export const lowVarianceChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
+  if (!generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: ['Nominal', 'Discrete', 'Ordinal'] }))
+    return false;
   const { measures } = subjectInfo;
   // 低方差检验使用变异系数 sigma/mean 作为检验统计量，要求均值不能为0
   if (['float', 'integer'].includes(fieldPropsMap[measures[0].fieldName].recommendation)) {
@@ -68,7 +69,7 @@ export const lowVarianceChecker: ExtractorChecker = (data, subjectInfo, fieldPro
   return false;
 };
 
-export const correlationChecker: ExtractorChecker = (data, subjectInfo, fieldPropsMap) => {
+export const correlationChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
   const { measures } = subjectInfo;
   // check data length
   if (data?.length < 3) return false;

--- a/packages/ava/src/insight/insights/checkers.ts
+++ b/packages/ava/src/insight/insights/checkers.ts
@@ -10,7 +10,7 @@ export type ExtractorChecker = (props: {
   subjectInfo: SubjectInfo;
   fieldPropsMap: Record<string, DataProperty>;
   lom?: LevelOfMeasurement | LevelOfMeasurement[];
-}) => boolean;
+}) => true | string;
 
 const fieldsQuantityChecker = (subjectInfo: SubjectInfo, dimensionsQuantity: number, measuresQuantity: number) => {
   const { dimensions, measures } = subjectInfo;
@@ -21,16 +21,16 @@ const fieldsQuantityChecker = (subjectInfo: SubjectInfo, dimensionsQuantity: num
 const generalCheckerFor1M1D: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap, lom }) => {
   const { dimensions } = subjectInfo;
   // check data length
-  if (data?.length < 3) return false;
+  if (data?.length < 3) return 'The data length is less than 3. ';
   // check field quantity
-  if (!fieldsQuantityChecker(subjectInfo, 1, 1)) return false;
+  if (!fieldsQuantityChecker(subjectInfo, 1, 1)) return 'The length of the measure or dimension is not 1. ';
   // check dimension type
   if (
     Array.isArray(lom)
       ? !intersection(fieldPropsMap[dimensions[0]]?.levelOfMeasurements, lom as LevelOfMeasurement[])?.length
       : !fieldPropsMap[dimensions[0]]?.levelOfMeasurements?.includes(lom as LevelOfMeasurement)
   )
-    return false;
+    return `The type of the dimension field is not included in the option ${Array.isArray(lom) ? lom : [lom]}. `;
   return true;
 };
 
@@ -51,35 +51,46 @@ export const timeSeriesChecker: ExtractorChecker = ({ data, subjectInfo, fieldPr
 };
 
 export const majorityChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
-  if (!generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: ['Nominal', 'Discrete', 'Ordinal', 'Time'] }))
-    return false;
+  const checkerFor1M1D = generalCheckerFor1M1D({
+    data,
+    subjectInfo,
+    fieldPropsMap,
+    lom: ['Nominal', 'Discrete', 'Ordinal', 'Time'],
+  });
+  if (checkerFor1M1D !== true) return checkerFor1M1D;
   const { measures } = subjectInfo;
-  if (!['count', 'sum'].includes(measures[0].method)) return false;
+  if (!['count', 'sum'].includes(measures[0].method)) return 'Measure is not aggregated in sum or count mode. ';
   return true;
 };
 
 export const lowVarianceChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
-  if (!generalCheckerFor1M1D({ data, subjectInfo, fieldPropsMap, lom: ['Nominal', 'Discrete', 'Ordinal'] }))
-    return false;
+  const checkerFor1M1D = generalCheckerFor1M1D({
+    data,
+    subjectInfo,
+    fieldPropsMap,
+    lom: ['Nominal', 'Discrete', 'Ordinal'],
+  });
+  if (checkerFor1M1D !== true) return checkerFor1M1D;
   const { measures } = subjectInfo;
   // 低方差检验使用变异系数 sigma/mean 作为检验统计量，要求均值不能为0
   if (['float', 'integer'].includes(fieldPropsMap[measures[0].fieldName].recommendation)) {
-    return (fieldPropsMap[measures[0].fieldName] as NumberFieldInfo).mean !== 0;
+    if ((fieldPropsMap[measures[0].fieldName] as NumberFieldInfo).mean !== 0) return true;
+    return 'The low variance test uses the coefficient of variation sigma/mean as the test statistic and requires that the mean cannot be 0. ';
   }
-  return false;
+  return 'The recommended data type of measure is not float or integer. ';
 };
 
 export const correlationChecker: ExtractorChecker = ({ data, subjectInfo, fieldPropsMap }) => {
   const { measures } = subjectInfo;
   // check data length
-  if (data?.length < 3) return false;
+  if (data?.length < 3) return 'The data length is less than 3. ';
   // check field quantity
-  if (measures.length !== 2) return false;
+  if (measures.length !== 2) return 'The length of the measure or dimension is not 2. ';
   if (
     !fieldPropsMap[measures[0].fieldName].levelOfMeasurements?.includes('Continuous') ||
     !fieldPropsMap[measures[1].fieldName].levelOfMeasurements?.includes('Continuous')
   )
-    return false;
+    return 'Level of measure is not continuous. ';
   return true;
 };
 

--- a/packages/ava/src/insight/insights/checkers.ts
+++ b/packages/ava/src/insight/insights/checkers.ts
@@ -90,7 +90,7 @@ export const correlationChecker: ExtractorChecker = ({ data, subjectInfo, fieldP
     !fieldPropsMap[measures[0].fieldName].levelOfMeasurements?.includes('Continuous') ||
     !fieldPropsMap[measures[1].fieldName].levelOfMeasurements?.includes('Continuous')
   )
-    return 'Level of measure is not continuous. ';
+    return 'Level of measurement is not continuous. ';
   return true;
 };
 

--- a/packages/ava/src/insight/insights/extractors/changePoint.ts
+++ b/packages/ava/src/insight/insights/extractors/changePoint.ts
@@ -1,24 +1,24 @@
-import { get } from 'lodash';
+import { get, isString } from 'lodash';
 
 import { changePoint } from '../../algorithms';
-import { getAlgorithmStandardInput, getNonSignificantInsight, preValidation } from '../util';
+import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
 
-import type { ChangePointInfo, GetPatternInfo } from '../../types';
+import type { ChangePointInfo, CommonParameter, GetPatternInfo } from '../../types';
 
 type ChangePointItem = {
   index: number;
   significance: number;
 };
 
-const SignificanceBenchmark = 0.85;
-
-export const findChangePoints = (series: number[], significance: number = 0.15): ChangePointItem[] => {
+export const findChangePoints = (series: number[], changePointsParameter: CommonParameter): ChangePointItem[] => {
   const results = changePoint.Bayesian(series);
 
   const changePointsResult: ChangePointItem[] = [];
-  const benchmark = significance ? 1 - significance : SignificanceBenchmark;
+  // significanceBenchmark is equivalent to the confidence interval in hypothesis testing
+  const significanceBenchmark = 1 - (changePointsParameter?.significance ?? 0.15);
   results.forEach((item) => {
-    if (item?.index >= 0 && item?.significance >= benchmark) {
+    // item.significance is similar to confidence interval
+    if (item?.index >= 0 && item?.significance >= significanceBenchmark) {
       changePointsResult.push(item);
     }
   });
@@ -28,13 +28,17 @@ export const findChangePoints = (series: number[], significance: number = 0.15):
 export const getChangePointInfo: GetPatternInfo<ChangePointInfo> = (props) => {
   const valid = preValidation(props);
   const insightType = 'change_point';
-  if (!valid) return getNonSignificantInsight({ insightType, infoType: 'verificationFailure' });
+  if (isString(valid))
+    return getNonSignificantInsight({ detailInfo: valid, insightType, infoType: 'verificationFailure' });
 
   const { data } = props;
-  const { dimension, values, measure } = getAlgorithmStandardInput(props);
-  const significance = get(props, 'options.algorithmParameter.changePoint.significance', 0.15);
-  const changePoints = findChangePoints(values, significance);
-  if (changePoints.length === 0) return getNonSignificantInsight({ insightType, infoType: 'noInsight' });
+  const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  const changePointsParameter = get(props, 'options.algorithmParameter.changePoint');
+  const changePoints = findChangePoints(values, changePointsParameter);
+  if (changePoints.length === 0) {
+    const info = 'Bayesian Online Changepoint Detection does not pass.';
+    return getNonSignificantInsight({ insightType, infoType: 'noInsight', customInfo: { info } });
+  }
 
   const outliers: ChangePointInfo[] = changePoints.map((item) => {
     const { index, significance } = item;
@@ -46,7 +50,7 @@ export const getChangePointInfo: GetPatternInfo<ChangePointInfo> = (props) => {
       index,
       x: data[index][dimension],
       y: data[index][measure] as number,
-      nonSignificantInsight: false,
+      significantInsight: true,
     };
   });
   return outliers;

--- a/packages/ava/src/insight/insights/extractors/changePoint.ts
+++ b/packages/ava/src/insight/insights/extractors/changePoint.ts
@@ -2,6 +2,7 @@ import { get, isString } from 'lodash';
 
 import { changePoint } from '../../algorithms';
 import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
+import { CHANGE_POINT_SIGNIFICANCE_BENCHMARK } from '../../constant';
 
 import type { ChangePointInfo, CommonParameter, GetPatternInfo } from '../../types';
 
@@ -15,7 +16,7 @@ export const findChangePoints = (series: number[], changePointsParameter: Common
 
   const changePointsResult: ChangePointItem[] = [];
   // significanceBenchmark is equivalent to the confidence interval in hypothesis testing
-  const significanceBenchmark = 1 - (changePointsParameter?.significance ?? 0.15);
+  const significanceBenchmark = 1 - (changePointsParameter?.threshold ?? CHANGE_POINT_SIGNIFICANCE_BENCHMARK);
   results.forEach((item) => {
     // item.significance is similar to confidence interval
     if (item?.index >= 0 && item?.significance >= significanceBenchmark) {

--- a/packages/ava/src/insight/insights/extractors/correlation.ts
+++ b/packages/ava/src/insight/insights/extractors/correlation.ts
@@ -4,6 +4,7 @@ import { pcorrtest } from '../../../data';
 import { PCorrTestParameter } from '../../../data/statistics/types';
 import { CorrelationInfo, GetPatternInfo } from '../../types';
 import { getNonSignificantInsight, preValidation } from '../util';
+import { DEFAULT_PCORRTEST_OPTIONS } from '../../../data/statistics/constants';
 
 type CorrelationResult = {
   significance: number;
@@ -42,7 +43,8 @@ export const getCorrelationInfo: GetPatternInfo<CorrelationInfo> = (props) => {
   const yField = measures[1].fieldName;
   const x = data.map((item) => item?.[xField] as number);
   const y = data.map((item) => item?.[yField] as number);
-  const result = findCorrelation(x, y, options?.algorithmParameter?.correlation);
+  const correlationParameter = options?.algorithmParameter?.correlation;
+  const result = findCorrelation(x, y, correlationParameter);
   if (result) {
     return [
       {
@@ -53,6 +55,8 @@ export const getCorrelationInfo: GetPatternInfo<CorrelationInfo> = (props) => {
       },
     ];
   }
-  const info = 'The Pearson product-moment correlation test does not pass at the specified significance (alpha).';
+  const info = `The Pearson product-moment correlation test does not pass at the specified significance level ${
+    correlationParameter?.alpha ?? DEFAULT_PCORRTEST_OPTIONS.alpha
+  }.`;
   return getNonSignificantInsight({ insightType, infoType: 'noInsight', customInfo: { info } });
 };

--- a/packages/ava/src/insight/insights/extractors/correlation.ts
+++ b/packages/ava/src/insight/insights/extractors/correlation.ts
@@ -1,13 +1,19 @@
 import { pcorrtest } from '../../../data';
-import { CorrelationInfo, InsightExtractorProp } from '../../types';
+import { PCorrTestOptions } from '../../../data/statistics/types';
+import { CorrelationInfo, GetPatternInfo } from '../../types';
+import { getNonSignificantInsight, preValidation } from '../util';
 
 type CorrelationResult = {
   significance: number;
   pcorr: number;
 };
 
-export function findCorrelation(x: number[], y: number[]): CorrelationResult | null {
-  const testResult = pcorrtest(x, y);
+export function findCorrelation(
+  x: number[],
+  y: number[],
+  correlationOptions?: PCorrTestOptions
+): CorrelationResult | null {
+  const testResult = pcorrtest(x, y, correlationOptions);
   // @ts-ignore Type Result is missing the "pcorr"
   const { rejected, pcorr } = testResult;
 
@@ -20,21 +26,25 @@ export function findCorrelation(x: number[], y: number[]): CorrelationResult | n
   return null;
 }
 
-export function extractor({ data, dimensions, measures }: InsightExtractorProp): CorrelationInfo[] {
+export const getCorrelationInfo: GetPatternInfo<CorrelationInfo> = (props) => {
+  const valid = preValidation(props);
+  const insightType = 'correlation';
+  const { data, measures, dimensions, options } = props;
+  if (!valid || !dimensions) return getNonSignificantInsight({ insightType, infoType: 'verificationFailure' });
   const xField = measures[0].fieldName;
   const yField = measures[1].fieldName;
-  if (!data || !dimensions || data.length === 0) return [];
   const x = data.map((item) => item?.[xField] as number);
   const y = data.map((item) => item?.[yField] as number);
-  const result = findCorrelation(x, y);
+  const result = findCorrelation(x, y, options?.algorithmParameter?.correlation);
   if (result) {
     return [
       {
         ...result,
-        type: 'correlation',
+        type: insightType,
         measures: [xField, yField],
+        nonSignificantInsight: false,
       },
     ];
   }
-  return [];
-}
+  return getNonSignificantInsight({ insightType, infoType: 'noInsight' });
+};

--- a/packages/ava/src/insight/insights/extractors/trend.ts
+++ b/packages/ava/src/insight/insights/extractors/trend.ts
@@ -4,6 +4,7 @@ import { get, isString } from 'lodash';
 import { CommonParameter, GetPatternInfo, TrendInfo } from '../../types';
 import { trendDirection } from '../../algorithms';
 import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
+import { SIGNIFICANCE_LEVEL } from '../../constant';
 
 type TrendResult = {
   significance: number;
@@ -12,7 +13,7 @@ type TrendResult = {
 };
 
 export function findTimeSeriesTrend(series: number[], trendParameter: CommonParameter): TrendResult {
-  const significance = trendParameter?.significance ?? 0.05;
+  const significance = trendParameter?.threshold ?? SIGNIFICANCE_LEVEL;
   const testResult = trendDirection.mkTest(series, significance);
   const { pValue, trend } = testResult;
 
@@ -47,7 +48,9 @@ export const getTrendInfo: GetPatternInfo<TrendInfo> = (props) => {
       ...(result.trend === 'no trend'
         ? {
             significantInsight: false,
-            info: 'The Mann-Kendall (MK) test does not pass at the specified significance (alpha).',
+            info: `The Mann-Kendall (MK) test does not pass at the specified significance level ${
+              trendParameter?.threshold ?? SIGNIFICANCE_LEVEL
+            }.`,
           }
         : {
             significantInsight: true,

--- a/packages/ava/src/insight/insights/index.ts
+++ b/packages/ava/src/insight/insights/index.ts
@@ -1,6 +1,6 @@
 import { flow } from 'lodash';
 
-import { InsightExtractorProps } from '../types';
+import { InsightExtractorProps, PatternInfo } from '../types';
 
 import { getCategoryOutlierInfo } from './extractors/categoryOutlier';
 import { getChangePointInfo } from './extractors/changePoint';
@@ -21,7 +21,7 @@ export const extractorMap = {
   correlation: getCorrelationInfo,
 };
 
-export const insightExtractor = (props: InsightExtractorProps) => {
+export const insightExtractor = (props: InsightExtractorProps): PatternInfo[] => {
   const { insightType = 'trend', options } = props;
   const { filterInsight = false } = options || {};
   const extractor = extractorMap[insightType];

--- a/packages/ava/src/insight/insights/index.ts
+++ b/packages/ava/src/insight/insights/index.ts
@@ -1,19 +1,31 @@
-import { extractor as categoryOutlierExtractor } from './extractors/categoryOutlier';
-import { extractor as trendExtractor } from './extractors/trend';
-import { extractor as ChangePointExtractor } from './extractors/changePoint';
-import { extractor as majorityExtractor } from './extractors/majority';
-import { extractor as lowVarianceExtractor } from './extractors/lowVariance';
-import { extractor as timeSeriesOutlierExtractor } from './extractors/timeSeriesOutlier';
-import { extractor as correlationExtractor } from './extractors/correlation';
+import { flow } from 'lodash';
 
-export const insightExtractors = {
-  category_outlier: categoryOutlierExtractor,
-  trend: trendExtractor,
-  change_point: ChangePointExtractor,
-  time_series_outlier: timeSeriesOutlierExtractor,
-  majority: majorityExtractor,
-  low_variance: lowVarianceExtractor,
-  correlation: correlationExtractor,
+import { InsightExtractorProps } from '../types';
+
+import { getCategoryOutlierInfo } from './extractors/categoryOutlier';
+import { getChangePointInfo } from './extractors/changePoint';
+import { getCorrelationInfo } from './extractors/correlation';
+import { getLowVarianceInfo } from './extractors/lowVariance';
+import { getMajorityInfo } from './extractors/majority';
+import { getTimeSeriesOutlierInfo } from './extractors/timeSeriesOutlier';
+import { getTrendInfo } from './extractors/trend';
+import { pickValidPattern } from './util';
+
+export const extractorMap = {
+  category_outlier: getCategoryOutlierInfo,
+  trend: getTrendInfo,
+  change_point: getChangePointInfo,
+  time_series_outlier: getTimeSeriesOutlierInfo,
+  majority: getMajorityInfo,
+  low_variance: getLowVarianceInfo,
+  correlation: getCorrelationInfo,
+};
+
+export const insightExtractor = (props: InsightExtractorProps) => {
+  const { insightType = 'trend', options } = props;
+  const { filterInsight = false } = options || {};
+  const extractor = extractorMap[insightType];
+  return flow([extractor, ...(filterInsight ? [pickValidPattern] : [])])(props);
 };
 
 export * from './checkers';

--- a/packages/ava/src/insight/insights/index.ts
+++ b/packages/ava/src/insight/insights/index.ts
@@ -21,7 +21,7 @@ export const extractorMap = {
   correlation: getCorrelationInfo,
 };
 
-export const insightExtractor = (props: InsightExtractorProps): PatternInfo[] => {
+export const insightPatternsExtractor = (props: InsightExtractorProps): PatternInfo[] => {
   const { insightType = 'trend', options } = props;
   const { filterInsight = false } = options || {};
   const extractor = extractorMap[insightType];

--- a/packages/ava/src/insight/pipeline/extract.ts
+++ b/packages/ava/src/insight/pipeline/extract.ts
@@ -2,7 +2,7 @@ import { groupBy, uniq, flatten, isString } from 'lodash';
 import Heap from 'heap-js';
 
 import { PATTERN_TYPES, InsightScoreBenchmark, ImpactScoreWeight } from '../constant';
-import { insightExtractor, ExtractorCheckers } from '../insights';
+import { insightPatternsExtractor, ExtractorCheckers } from '../insights';
 import { aggregate } from '../utils/aggregate';
 import {
   extractHomogeneousPatternsForMeasures,
@@ -71,7 +71,7 @@ function extractPatternsFromSubject(
     if (insightExtractorChecker) {
       if (isString(insightExtractorChecker({ data, subjectInfo, fieldPropsMap }))) isValid = false;
     }
-    if (isValid && insightExtractor) {
+    if (isValid && insightPatternsExtractor) {
       const { algorithmParameter, dataProcessInfo } = options || {};
       const extractorOptions: InsightExtractorOptions = {
         algorithmParameter,
@@ -81,7 +81,7 @@ function extractPatternsFromSubject(
         // Select only significant insights
         filterInsight: true,
       };
-      const extractedPatterns = insightExtractor({
+      const extractedPatterns = insightPatternsExtractor({
         data,
         dimensions,
         measures,

--- a/packages/ava/src/insight/pipeline/extract.ts
+++ b/packages/ava/src/insight/pipeline/extract.ts
@@ -1,4 +1,4 @@
-import { groupBy, uniq, flatten } from 'lodash';
+import { groupBy, uniq, flatten, isString } from 'lodash';
 import Heap from 'heap-js';
 
 import { PATTERN_TYPES, InsightScoreBenchmark, ImpactScoreWeight } from '../constant';
@@ -69,7 +69,7 @@ function extractPatternsFromSubject(
 
     // Check whether the data requirements of the extractor are met
     if (insightExtractorChecker) {
-      if (!insightExtractorChecker({ data, subjectInfo, fieldPropsMap })) isValid = false;
+      if (isString(insightExtractorChecker({ data, subjectInfo, fieldPropsMap }))) isValid = false;
     }
     if (isValid && insightExtractor) {
       const { algorithmParameter, dataProcessInfo } = options || {};

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -1,4 +1,4 @@
-import { PCorrTestOptions } from '../data/statistics/types';
+import { PCorrTestParameter } from '../data/statistics/types';
 
 import { PATTERN_TYPES, HOMOGENEOUS_PATTERN_TYPES } from './constant';
 
@@ -118,17 +118,17 @@ export type InsightVisualizationOptions = {
   lang: Language;
 };
 
-export type LowVarianceParams = {
+export type LowVarianceParameter = {
   /** Default value is 0.15  */
   cvThreshold?: number;
 };
 
-export type MajorityParams = {
+export type MajorityParameter = {
   /** Proportion greater than limit is considered as significant. Default value is 0.6 */
   limit?: number;
 };
 
-export type OutlierParams = {
+export type OutlierParameter = {
   /**
    * - IQR: Inter Quartile Range method which is used by default. A point is considered an outlier when it lies outside of iqrK times the inter quartile range.
    * - p-value: Assuming that the data follows a normal distribution, a point is considered an outlier if the two-sided test p-value is less than 1-confidenceInterval.
@@ -140,8 +140,8 @@ export type OutlierParams = {
   confidenceInterval?: number;
 };
 
-export type CommonParams = {
-  /** Significance level (alpha) in test */
+export type CommonParameter = {
+  /** Significance level (alpha) in hypothesis testing */
   significance?: number;
 };
 
@@ -150,14 +150,14 @@ export type AlgorithmParameter = {
   /**
    * Contains both category outlier and time series outlier
    * */
-  outlier?: OutlierParams;
+  outlier?: OutlierParameter;
   /** time series trend, Default value of significance is 0.05 */
-  trend?: CommonParams;
+  trend?: CommonParameter;
   /** Significance level (alpha) in Bayesian online change point detection. Default value is 0.15 */
-  changePoint?: CommonParams;
-  correlation?: PCorrTestOptions;
-  lowVariance?: LowVarianceParams;
-  majority?: MajorityParams;
+  changePoint?: CommonParameter;
+  correlation?: PCorrTestParameter;
+  lowVariance?: LowVarianceParameter;
+  majority?: MajorityParameter;
 };
 
 export type InsightExtractorOptions = {
@@ -218,8 +218,9 @@ export interface InsightOptions {
 export interface BasePatternInfo<T extends InsightType> {
   type: T;
   significance: number;
-  /** Non significant insight at the specified significance threshold */
-  nonSignificantInsight?: boolean;
+  /** Significant insight at the specified significance threshold */
+  significantInsight?: boolean;
+  info?: string;
 }
 
 export interface HomogeneousPatternInfo {
@@ -273,10 +274,8 @@ export type CorrelationInfo = BasePatternInfo<'correlation'> & {
   measures: [string, string];
 };
 
-export type NoPatternInfo = {
-  nonSignificantInsight: boolean;
+export type NoPatternInfo = BasePatternInfo<InsightType> & {
   info: string;
-  type?: InsightType;
   [key: string]: any;
 };
 

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -142,7 +142,7 @@ export type OutlierParameter = {
 
 export type CommonParameter = {
   /** Significance level (alpha) in hypothesis testing */
-  significance?: number;
+  threshold?: number;
 };
 
 /** Key parameters in the algorithm for extracting insights */


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
 
改造insightExtractors方法，支持指定insightType，获取单个算子的结论，用法如下

```ts
const trendInsights = insightExtractor({
  data,
  measures,
  dimensions,
  insightType: 'trend',
}) 
```
已更新测试用例 并通过
![image](https://github.com/antvis/AVA/assets/71261480/47cdb0a6-ef06-48d4-bd35-be26ad31e9a2)

- [ ] fixed #0
- [x] add / modify test cases
- [ ] documents, demos
