### PR TITLE
feat(ava/insight): generate marks of a specific insight type

### DIFF
--- a/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/category-outlier.test.ts
@@ -39,7 +39,7 @@ describe('extract category-outlier insight', () => {
   test('check outliers result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['type'],
+      dimensions: [{ fieldName: 'type' }],
       measures: [{ fieldName: 'sales', method: 'SUM' }],
       insightType: 'category_outlier',
       options: {

--- a/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/change-point.test.ts
@@ -16,7 +16,7 @@ describe('extract change-point insight', () => {
   test('check change-point result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['year'],
+      dimensions: [{ fieldName: 'year' }],
       measures: [{ fieldName: 'value', method: 'SUM' }],
       insightType: 'change_point',
       options: {

--- a/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/low-variance.test.ts
@@ -39,7 +39,7 @@ describe('extract low-variance insight', () => {
   test('check low-variance result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['type'],
+      dimensions: [{ fieldName: 'type' }],
       measures: [{ fieldName: 'sales', method: 'SUM' }],
       insightType: 'low_variance',
       options: {

--- a/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/majority.test.ts
@@ -39,7 +39,7 @@ describe('extract majority insight', () => {
   test('check majority result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['type'],
+      dimensions: [{ fieldName: 'type' }],
       measures: [{ fieldName: 'sales', method: 'SUM' }],
       insightType: 'majority',
       options: {

--- a/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/time-series-outlier.test.ts
@@ -16,7 +16,7 @@ describe('extract time-series-outlier insight', () => {
   test('check outliers result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['year'],
+      dimensions: [{ fieldName: 'year' }],
       measures: [{ fieldName: 'value', method: 'SUM' }],
       insightType: 'time_series_outlier',
       options: {

--- a/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
+++ b/packages/ava/__tests__/unit/insight/extractors/trend.test.ts
@@ -16,7 +16,7 @@ describe('extract trend insight', () => {
   test('check trend result', () => {
     const result = insightPatternsExtractor({
       data,
-      dimensions: ['year'],
+      dimensions: [{ fieldName: 'year' }],
       measures: [{ fieldName: 'value', method: 'SUM' }],
       insightType: 'trend',
       options: {

--- a/packages/ava/src/index.ts
+++ b/packages/ava/src/index.ts
@@ -93,7 +93,7 @@ export type {
 } from './data';
 
 /* insight */
-export { getInsights, generateInsightVisualizationSpec, insightPatternsExtractor } from './insight';
+export { getInsights, generateInsightVisualizationSpec, insightPatternsExtractor, getSpecificInsight } from './insight';
 export type {
   Datum,
   DomainType,

--- a/packages/ava/src/index.ts
+++ b/packages/ava/src/index.ts
@@ -93,7 +93,7 @@ export type {
 } from './data';
 
 /* insight */
-export { getInsights, generateInsightVisualizationSpec, insightPatternsExtractor, getSpecificInsight } from './insight';
+export { getInsights, generateInsightVisualizationSpec, insightPatternsExtractor } from './insight';
 export type {
   Datum,
   DomainType,

--- a/packages/ava/src/insight/constant.ts
+++ b/packages/ava/src/insight/constant.ts
@@ -3,11 +3,11 @@ export const SIGNIFICANCE_BENCHMARK = 0.95;
 
 export const SIGNIFICANCE_LEVEL = 0.05;
 
-export const InsightScoreBenchmark = 0.01;
+export const INSIGHT_SCORE_BENCHMARK = 0.01;
 
 export const IMPACT_SCORE_WEIGHT = 0.2;
 
-export const InsightDefaultLimit = 20;
+export const INSIGHT_DEFAULT_LIMIT = 20;
 
 export const IQR_K = 1.5;
 

--- a/packages/ava/src/insight/constant.ts
+++ b/packages/ava/src/insight/constant.ts
@@ -5,7 +5,7 @@ export const SIGNIFICANCE_LEVEL = 0.05;
 
 export const InsightScoreBenchmark = 0.01;
 
-export const ImpactScoreWeight = 0.2;
+export const IMPACT_SCORE_WEIGHT = 0.2;
 
 export const InsightDefaultLimit = 20;
 

--- a/packages/ava/src/insight/index.ts
+++ b/packages/ava/src/insight/index.ts
@@ -2,3 +2,4 @@ export { getInsights } from './pipeline';
 export { insightPatternsExtractor } from './insights';
 export { generateInsightVisualizationSpec } from './pipeline/visualize';
 export * from './types';
+export { getSpecificInsight } from './pipeline/specificInsight';

--- a/packages/ava/src/insight/insights/extractors/categoryOutlier.ts
+++ b/packages/ava/src/insight/insights/extractors/categoryOutlier.ts
@@ -1,4 +1,4 @@
-import { get, isString, orderBy } from 'lodash';
+import { get, isNil, isString, orderBy } from 'lodash';
 
 import { distinct, mean } from '../../../data';
 import { categoryOutlier } from '../../algorithms';
@@ -76,6 +76,13 @@ export const getCategoryOutlierInfo: GetPatternInfo<CategoryOutlierInfo> = (prop
   if (isString(valid))
     return getNonSignificantInsight({ detailInfo: valid, insightType, infoType: 'verificationFailure' });
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
+
   if (distinct(values) === 1)
     return getNonSignificantInsight({
       insightType,

--- a/packages/ava/src/insight/insights/extractors/changePoint.ts
+++ b/packages/ava/src/insight/insights/extractors/changePoint.ts
@@ -1,4 +1,4 @@
-import { get, isString } from 'lodash';
+import { get, isNil, isString } from 'lodash';
 
 import { changePoint } from '../../algorithms';
 import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
@@ -34,6 +34,13 @@ export const getChangePointInfo: GetPatternInfo<ChangePointInfo> = (props) => {
 
   const { data } = props;
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
+
   const changePointsParameter = get(props, 'options.algorithmParameter.changePoint');
   const changePoints = findChangePoints(values, changePointsParameter);
   if (changePoints.length === 0) {

--- a/packages/ava/src/insight/insights/extractors/lowVariance.ts
+++ b/packages/ava/src/insight/insights/extractors/lowVariance.ts
@@ -1,4 +1,4 @@
-import { get, isString } from 'lodash';
+import { get, isNil, isString } from 'lodash';
 
 import { coefficientOfVariance, mean } from '../../../data';
 import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
@@ -36,6 +36,13 @@ export const getLowVarianceInfo: GetPatternInfo<LowVarianceInfo> = (props) => {
   if (isString(valid))
     return getNonSignificantInsight({ detailInfo: valid, insightType, infoType: 'verificationFailure' });
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
+
   const lowVarianceParameter = get(props, 'options.algorithmParameter.lowVariance');
   const lowVariance = findLowVariance(values, lowVarianceParameter);
   if (lowVariance) {

--- a/packages/ava/src/insight/insights/extractors/majority.ts
+++ b/packages/ava/src/insight/insights/extractors/majority.ts
@@ -1,4 +1,4 @@
-import { get, isString } from 'lodash';
+import { get, isNil, isString } from 'lodash';
 
 import { getAlgorithmCommonInput, getNonSignificantInsight, preValidation } from '../util';
 
@@ -47,6 +47,13 @@ export const getMajorityInfo: GetPatternInfo<MajorityInfo> = (props) => {
     return getNonSignificantInsight({ detailInfo: valid, insightType, infoType: 'verificationFailure' });
   const { data } = props;
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
+
   const majorityParameter = get(props, 'options.algorithmParameter.majority');
   const majority = findMajority(values, majorityParameter);
   if (majority) {

--- a/packages/ava/src/insight/insights/extractors/timeSeriesOutlier.ts
+++ b/packages/ava/src/insight/insights/extractors/timeSeriesOutlier.ts
@@ -1,4 +1,4 @@
-import { get, isString } from 'lodash';
+import { get, isNil, isString } from 'lodash';
 
 import { distinct, lowess } from '../../../data';
 import { LowessOutput } from '../../../data/statistics/types';
@@ -41,6 +41,12 @@ export const getTimeSeriesOutlierInfo: GetPatternInfo<TimeSeriesOutlierInfo> = (
 
   const { data } = props;
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
 
   if (distinct(values) === 1) return getNonSignificantInsight({ insightType, infoType: 'noInsight' });
 

--- a/packages/ava/src/insight/insights/extractors/trend.ts
+++ b/packages/ava/src/insight/insights/extractors/trend.ts
@@ -1,5 +1,5 @@
 import regression from 'regression';
-import { get, isString } from 'lodash';
+import { get, isNil, isString } from 'lodash';
 
 import { CommonParameter, GetPatternInfo, TrendInfo } from '../../types';
 import { trendDirection } from '../../algorithms';
@@ -37,6 +37,13 @@ export const getTrendInfo: GetPatternInfo<TrendInfo> = (props) => {
     return getNonSignificantInsight({ detailInfo: valid, insightType, infoType: 'verificationFailure' });
 
   const { dimension, values, measure } = getAlgorithmCommonInput(props);
+  if (isNil(dimension) || isNil(measure))
+    return getNonSignificantInsight({
+      detailInfo: 'Measure or dimension is empty.',
+      insightType,
+      infoType: 'verificationFailure',
+    });
+
   const trendParameter = get(props, 'options.algorithmParameter.trend');
   const result: TrendResult = findTimeSeriesTrend(values, trendParameter);
   return [

--- a/packages/ava/src/insight/insights/util.ts
+++ b/packages/ava/src/insight/insights/util.ts
@@ -49,8 +49,8 @@ export const getAlgorithmCommonInput = ({
   dimensions,
   measures,
 }: InsightExtractorProps): AlgorithmStandardInput => {
-  const dimension = dimensions[0];
-  const measure = measures[0].fieldName;
+  const dimension = dimensions[0]?.fieldName;
+  const measure = measures[0]?.fieldName;
   const values = data.map((item) => item?.[measure] as number);
   return { dimension, measure, values };
 };
@@ -75,7 +75,7 @@ export const preValidation = ({
   if (!checker) return true;
   const result = checker({
     data,
-    subjectInfo: { dimensions, measures, subspace: [] },
+    subjectInfo: { dimensions: dimensions?.map((dim) => dim.fieldName), measures, subspace: [] },
     fieldPropsMap,
   });
   return result;

--- a/packages/ava/src/insight/pipeline/extract.ts
+++ b/packages/ava/src/insight/pipeline/extract.ts
@@ -1,7 +1,7 @@
 import { groupBy, uniq, flatten, isString } from 'lodash';
 import Heap from 'heap-js';
 
-import { PATTERN_TYPES, InsightScoreBenchmark, ImpactScoreWeight } from '../constant';
+import { PATTERN_TYPES, InsightScoreBenchmark, IMPACT_SCORE_WEIGHT } from '../constant';
 import { insightPatternsExtractor, ExtractorCheckers } from '../insights';
 import { aggregate } from '../utils/aggregate';
 import {
@@ -217,7 +217,7 @@ export function extractInsightsFromSubspace(
   const impactScoreWeight =
     !!options?.impactWeight && options.impactWeight >= 0 && options.impactWeight < 1
       ? options.impactWeight
-      : ImpactScoreWeight;
+      : IMPACT_SCORE_WEIGHT;
   const optimalScore = subspaceImpact * impactScoreWeight + 1 * (1 - impactScoreWeight);
   if (insightsHeap.length >= insightsHeap.limit) {
     const minScoreInHeap = insightsHeap.peek()?.score as number;

--- a/packages/ava/src/insight/pipeline/extract.ts
+++ b/packages/ava/src/insight/pipeline/extract.ts
@@ -1,7 +1,7 @@
 import { groupBy, uniq, flatten, isString } from 'lodash';
 import Heap from 'heap-js';
 
-import { PATTERN_TYPES, InsightScoreBenchmark, IMPACT_SCORE_WEIGHT } from '../constant';
+import { PATTERN_TYPES, INSIGHT_SCORE_BENCHMARK, IMPACT_SCORE_WEIGHT } from '../constant';
 import { insightPatternsExtractor, ExtractorCheckers } from '../insights';
 import { aggregate } from '../utils/aggregate';
 import {
@@ -83,7 +83,7 @@ function extractPatternsFromSubject(
       };
       const extractedPatterns = insightPatternsExtractor({
         data,
-        dimensions,
+        dimensions: dimensions.map((dim) => ({ fieldName: dim })),
         measures,
         insightType,
         options: extractorOptions,
@@ -209,7 +209,7 @@ export function extractInsightsFromSubspace(
   const subspaceImpact = computeSubspaceImpact(data, subspace, impactMeasureReferences, options?.impactMeasures);
 
   // pruning1: check the subpace impact limit
-  if (subspaceImpact < InsightScoreBenchmark) {
+  if (subspaceImpact < INSIGHT_SCORE_BENCHMARK) {
     return [];
   }
 

--- a/packages/ava/src/insight/pipeline/insight.ts
+++ b/packages/ava/src/insight/pipeline/insight.ts
@@ -1,6 +1,6 @@
 import Heap from 'heap-js';
 
-import { InsightDefaultLimit } from '../constant';
+import { INSIGHT_DEFAULT_LIMIT } from '../constant';
 import { aggregateWithSeries, aggregateWithMeasures } from '../utils/aggregate';
 
 import { enumerateInsights } from './extract';
@@ -61,7 +61,7 @@ export function extractInsights(sourceData: Datum[], options?: InsightOptions): 
   // init insights storage
   const insightsHeap = new Heap(insightPriorityComparator);
   const homogeneousInsightsHeap = new Heap(homogeneousInsightPriorityComparator);
-  const insightsLimit = options?.limit || InsightDefaultLimit;
+  const insightsLimit = options?.limit || INSIGHT_DEFAULT_LIMIT;
   insightsHeap.limit = insightsLimit;
   insightsHeap.init([]);
   homogeneousInsightsHeap.init([]);

--- a/packages/ava/src/insight/pipeline/specificInsight.ts
+++ b/packages/ava/src/insight/pipeline/specificInsight.ts
@@ -1,0 +1,62 @@
+import { G2Spec, Mark } from '@antv/g2';
+import { zipObject } from 'lodash';
+
+import { changePointAugmentedMarksStrategy, generateInsightChartSpec, trendAugmentedMarksStrategy } from '../chart';
+import { timeSeriesOutlierStrategyAugmentedMarksStrategy } from '../chart/strategy/augmentedMarks/timeSeriesOutlier';
+import { IMPACT_SCORE_WEIGHT } from '../constant';
+import { insightPatternsExtractor } from '../insights';
+import { InsightInfo, PatternInfo, PatternInfo2InsightInfoProps, SpecificInsightProps } from '../types';
+
+export const patternInfo2InsightInfo = (props: PatternInfo2InsightInfoProps) => {
+  const { dimensions, measures, data, patternInfos } = props;
+  const score = patternInfos[0] ? patternInfos[0].significance * (1 - IMPACT_SCORE_WEIGHT) + IMPACT_SCORE_WEIGHT : 0;
+  return {
+    subspace: [],
+    dimensions: [
+      {
+        fieldName: dimensions[0],
+      },
+    ],
+    measures,
+    patterns: patternInfos,
+    data,
+    score,
+  };
+};
+
+export const getAnnotationSpec = (insightInfo: InsightInfo<PatternInfo>): Record<string, G2Spec> => {
+  const { type: insightType } = insightInfo.patterns[0];
+
+  const insightType2AugmentedMarks = {
+    trend: trendAugmentedMarksStrategy,
+    change_point: changePointAugmentedMarksStrategy,
+    time_series_outlier: timeSeriesOutlierStrategyAugmentedMarksStrategy,
+  };
+  const markList = insightType2AugmentedMarks[insightType]?.(insightInfo) as Mark[];
+  const markMap = zipObject(
+    markList.map((mark) => mark.type as string),
+    markList
+  );
+  return markMap;
+};
+
+export const getSpecificInsight = (props: SpecificInsightProps): InsightInfo<PatternInfo> => {
+  // 计算patternInfo
+  const patternInfos = insightPatternsExtractor(props);
+  // 获取insightInfo
+  const insightInfo = patternInfo2InsightInfo({ ...props, patternInfos });
+  // 获取annotationSpec
+  const annotationSpec = getAnnotationSpec(insightInfo);
+  const chartSpec = generateInsightChartSpec(insightInfo);
+
+  return {
+    ...insightInfo,
+    visualizationSpecs: [
+      {
+        annotationSpec,
+        chartSpec,
+        patternType: props.insightType,
+      },
+    ],
+  };
+};

--- a/packages/ava/src/insight/pipeline/specificInsight.ts
+++ b/packages/ava/src/insight/pipeline/specificInsight.ts
@@ -12,11 +12,7 @@ export const patternInfo2InsightInfo = (props: PatternInfo2InsightInfoProps) => 
   const score = patternInfos[0] ? patternInfos[0].significance * (1 - IMPACT_SCORE_WEIGHT) + IMPACT_SCORE_WEIGHT : 0;
   return {
     subspace: [],
-    dimensions: [
-      {
-        fieldName: dimensions[0],
-      },
-    ],
+    dimensions,
     measures,
     patterns: patternInfos,
     data,

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -80,6 +80,8 @@ export type PatternInfo =
 export interface InsightVisualizationSpec {
   patternType: InsightType;
   chartSpec: G2Spec;
+  /** augmented marks */
+  annotationSpec?: Record<string, G2Spec>;
   /**
    * @description explain insight by text
    * @default ParagraphSpec[]
@@ -282,4 +284,17 @@ export type NoPatternInfo = BasePatternInfo<InsightType> & {
 export type InsightsResult = {
   insights: InsightInfo<PatternInfo>[];
   homogeneousInsights?: InsightInfo<HomogeneousPatternInfo>[];
+};
+
+export type SpecificInsightProps = {
+  data: Datum[];
+  dimensions: string[];
+  measures: Measure[];
+  insightType: InsightType;
+  /** 包括自定义的算法参数，是否进行数据校验等内容 */
+  options?: InsightExtractorOptions;
+};
+
+export type PatternInfo2InsightInfoProps = SpecificInsightProps & {
+  patternInfos: PatternInfo[];
 };

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -175,7 +175,7 @@ export type InsightExtractorOptions = {
 
 export type InsightExtractorProps = {
   data: Datum[];
-  dimensions: string[];
+  dimensions: Dimension[];
   measures: Measure[];
   insightType: InsightType;
   options?: InsightExtractorOptions;
@@ -288,7 +288,7 @@ export type InsightsResult = {
 
 export type SpecificInsightProps = {
   data: Datum[];
-  dimensions: string[];
+  dimensions: Dimension[];
   measures: Measure[];
   insightType: InsightType;
   /** 包括自定义的算法参数，是否进行数据校验等内容 */


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

指定洞察类型生成对应的insightInfo
![image](https://github.com/antvis/AVA/assets/71261480/77e303f5-05f1-4f2d-a61e-8b6c8c974d02)
