### PR TITLE
fix(ava/insight): only generate annotationSpec for valid patternInfo

### DIFF
--- a/packages/ava/src/insight/chart/strategy/commonMarks/pointMark.ts
+++ b/packages/ava/src/insight/chart/strategy/commonMarks/pointMark.ts
@@ -1,11 +1,16 @@
 import { Mark } from '@antv/g2';
+import { isNil } from 'lodash';
 
 import { PointPatternInfo } from '../../../types';
 import { PointMarkConfig } from '../../types';
 
 /** get mark for point patterns, the patterns should have same dimension and measure */
 export const pointMarkStrategy = (patterns: PointPatternInfo[], config: PointMarkConfig): Mark => {
-  const data = patterns.map(({ x, y }) => ({ x, y }));
+  const data = [];
+  patterns.forEach(({ x, y }) => {
+    if (isNil(x) || isNil(y)) return;
+    data.push({ x, y });
+  });
 
   const pointMark: Mark = {
     type: 'point',

--- a/packages/ava/src/insight/insights/util.ts
+++ b/packages/ava/src/insight/insights/util.ts
@@ -1,4 +1,4 @@
-import { mean } from 'lodash';
+import { isNil, mean } from 'lodash';
 
 import { standardDeviation, cdf, normalDistributionQuantile, max, min } from '../../data';
 import {
@@ -9,6 +9,7 @@ import {
   NoPatternInfo,
   PatternInfo,
   PreValidationProps,
+  TimeSeriesOutlierInfo,
 } from '../types';
 import { dataToDataProps } from '../pipeline/preprocess';
 import { NO_PATTERN_INFO, VERIFICATION_FAILURE_INFO } from '../constant';
@@ -49,8 +50,8 @@ export const getAlgorithmCommonInput = ({
   dimensions,
   measures,
 }: InsightExtractorProps): AlgorithmStandardInput => {
-  const dimension = dimensions[0]?.fieldName;
-  const measure = measures[0]?.fieldName;
+  const dimension = dimensions?.[0]?.fieldName;
+  const measure = measures?.[0]?.fieldName;
   const values = data.map((item) => item?.[measure] as number);
   return { dimension, measure, values };
 };
@@ -106,4 +107,8 @@ export const getNonSignificantInsight = ({
 
 export const pickValidPattern = (infos: PatternInfo[] = []): PatternInfo[] => {
   return infos.filter((info) => info.significantInsight);
+};
+
+export const pickValidTimeSeriesOutlierPatterns = (infos: TimeSeriesOutlierInfo[] = []): TimeSeriesOutlierInfo[] => {
+  return infos.filter((info) => ![info.baselines, info.thresholds, info.x].every(isNil));
 };

--- a/packages/ava/src/insight/pipeline/specificInsight.ts
+++ b/packages/ava/src/insight/pipeline/specificInsight.ts
@@ -1,23 +1,28 @@
+import { size } from 'lodash';
+
 import {
   generateInsightChartSpec,
   changePointAugmentedMarksStrategy,
   trendAugmentedMarksStrategy,
   timeSeriesOutlierStrategyAugmentedMarksStrategy,
   AugmentedMarks,
+  lowVarianceAugmentedMarkStrategy,
+  categoryOutlierAugmentedMarksStrategy,
 } from '../chart';
 import { insightPatternsExtractor } from '../insights';
 import {
   InsightInfo,
+  InsightType,
   PatternInfo,
   PatternInfo2InsightInfoProps,
   SpecificInsightProps,
   SpecificInsightResult,
+  TimeSeriesOutlierInfo,
 } from '../types';
 import generateInsightNarrative from '../narrative';
+import { pickValidPattern, pickValidTimeSeriesOutlierPatterns } from '../insights/util';
 
-export const patternInfo2InsightInfo = (
-  props: PatternInfo2InsightInfoProps
-): Omit<InsightInfo<PatternInfo>, 'score'> => {
+export const patternInfo2InsightInfo = (props: PatternInfo2InsightInfoProps): SpecificInsightResult => {
   const { dimensions, measures, data, patternInfos } = props;
   return {
     subspace: [],
@@ -29,33 +34,54 @@ export const patternInfo2InsightInfo = (
 };
 
 export const getAnnotationSpec = (insightInfo: InsightInfo<PatternInfo>): AugmentedMarks => {
-  const { type: insightType } = insightInfo.patterns[0];
+  const { type: insightType } = insightInfo.patterns[0] ?? {};
 
   const insightType2AugmentedMarks = {
     trend: trendAugmentedMarksStrategy,
     change_point: changePointAugmentedMarksStrategy,
     time_series_outlier: timeSeriesOutlierStrategyAugmentedMarksStrategy,
+    low_variance: lowVarianceAugmentedMarkStrategy,
+    category_outlier: categoryOutlierAugmentedMarksStrategy,
   };
   return insightType2AugmentedMarks[insightType]?.(insightInfo);
 };
 
-export const getSpecificInsight = (props: SpecificInsightProps): SpecificInsightResult => {
-  const { visualizationOptions = { lang: 'zh-CN' } } = props.options || {};
-  const patternInfos = insightPatternsExtractor(props);
-  const insightInfo = patternInfo2InsightInfo({ ...props, patternInfos });
-  const annotationSpec = getAnnotationSpec(insightInfo);
-  const chartSpec = generateInsightChartSpec(insightInfo);
-  const narrativeSpec = generateInsightNarrative(insightInfo, visualizationOptions);
+export const filterValidInsightInfoForAnnotationSpec = ({
+  patternInfos = [],
+  insightType,
+}: {
+  patternInfos: PatternInfo[];
+  insightType: InsightType;
+}) => {
+  if (insightType === 'time_series_outlier')
+    return pickValidTimeSeriesOutlierPatterns(patternInfos as TimeSeriesOutlierInfo[]);
+  return pickValidPattern(patternInfos);
+};
 
-  return {
-    ...insightInfo,
-    visualizationSpecs: [
-      {
-        annotationSpec,
-        chartSpec,
-        patternType: props.insightType,
-        narrativeSpec,
-      },
-    ],
-  };
+export const getSpecificInsight = (props: SpecificInsightProps): SpecificInsightResult => {
+  const { options = {}, insightType } = props;
+  const { visualizationOptions = { lang: 'zh-CN' } } = options;
+  const patternInfos = insightPatternsExtractor(props);
+  const validPatternInfos = filterValidInsightInfoForAnnotationSpec({ patternInfos, insightType });
+  const totalInsightInfo = patternInfo2InsightInfo({ ...props, patternInfos });
+
+  if (size(validPatternInfos)) {
+    const validInsightInfo = patternInfo2InsightInfo({ ...props, patternInfos: validPatternInfos });
+    const annotationSpec = getAnnotationSpec(validInsightInfo);
+    const chartSpec = generateInsightChartSpec(validInsightInfo);
+    const narrativeSpec = generateInsightNarrative(validInsightInfo, visualizationOptions);
+    return {
+      ...totalInsightInfo,
+      visualizationSpecs: [
+        {
+          annotationSpec,
+          chartSpec,
+          patternType: props.insightType,
+          narrativeSpec,
+        },
+      ],
+    };
+  }
+
+  return { ...totalInsightInfo };
 };

--- a/packages/ava/src/insight/pipeline/specificInsight.ts
+++ b/packages/ava/src/insight/pipeline/specificInsight.ts
@@ -40,7 +40,7 @@ export const getAnnotationSpec = (insightInfo: InsightInfo<PatternInfo>): Augmen
 };
 
 export const getSpecificInsight = (props: SpecificInsightProps): SpecificInsightResult => {
-  const { visualizationOptions } = props.options || {};
+  const { visualizationOptions = { lang: 'zh-CN' } } = props.options || {};
   const patternInfos = insightPatternsExtractor(props);
   const insightInfo = patternInfo2InsightInfo({ ...props, patternInfos });
   const annotationSpec = getAnnotationSpec(insightInfo);

--- a/packages/ava/src/insight/pipeline/specificInsight.ts
+++ b/packages/ava/src/insight/pipeline/specificInsight.ts
@@ -1,4 +1,5 @@
 import { size } from 'lodash';
+import { G2Spec } from '@antv/g2';
 
 import {
   generateInsightChartSpec,
@@ -21,8 +22,9 @@ import {
 } from '../types';
 import generateInsightNarrative from '../narrative';
 import { pickValidPattern, pickValidTimeSeriesOutlierPatterns } from '../insights/util';
+import { insight2ChartStrategy, viewSpecStrategy } from '../chart/strategy';
 
-export const patternInfo2InsightInfo = (props: PatternInfo2InsightInfoProps): SpecificInsightResult => {
+export const patternInfo2InsightInfo = (props: PatternInfo2InsightInfoProps): InsightInfo<PatternInfo> => {
   const { dimensions, measures, data, patternInfos } = props;
   return {
     subspace: [],
@@ -44,6 +46,11 @@ export const getAnnotationSpec = (insightInfo: InsightInfo<PatternInfo>): Augmen
     category_outlier: categoryOutlierAugmentedMarksStrategy,
   };
   return insightType2AugmentedMarks[insightType]?.(insightInfo);
+};
+
+export const getChartSpecWithoutAugmentedMarks = (insightInfo: InsightInfo<PatternInfo>): G2Spec => {
+  const chartMark = insight2ChartStrategy(insightInfo);
+  return viewSpecStrategy([chartMark], insightInfo);
 };
 
 export const filterValidInsightInfoForAnnotationSpec = ({
@@ -76,12 +83,22 @@ export const getSpecificInsight = (props: SpecificInsightProps): SpecificInsight
         {
           annotationSpec,
           chartSpec,
-          patternType: props.insightType,
+          patternType: insightType,
           narrativeSpec,
         },
       ],
     };
   }
 
-  return { ...totalInsightInfo };
+  const chartSpec = getChartSpecWithoutAugmentedMarks(totalInsightInfo);
+
+  return {
+    ...totalInsightInfo,
+    visualizationSpecs: [
+      {
+        chartSpec,
+        patternType: insightType,
+      },
+    ],
+  };
 };

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -286,8 +286,8 @@ export type InsightsResult = {
 
 export type SpecificInsightProps = InsightExtractorProps;
 
-export type SpecificInsightResult = Omit<InsightInfo<PatternInfo>, 'score'> & {
-  visualizationSpecs: Required<InsightVisualizationSpec>[];
+export type SpecificInsightResult = Omit<InsightInfo<PatternInfo>, 'score' | 'visualizationSpecs'> & {
+  visualizationSpecs?: Required<InsightVisualizationSpec>[];
 };
 
 export type PatternInfo2InsightInfoProps = SpecificInsightProps & {

--- a/packages/ava/src/insight/types.ts
+++ b/packages/ava/src/insight/types.ts
@@ -286,9 +286,7 @@ export type InsightsResult = {
 
 export type SpecificInsightProps = InsightExtractorProps;
 
-export type SpecificInsightResult = Omit<InsightInfo<PatternInfo>, 'score' | 'visualizationSpecs'> & {
-  visualizationSpecs?: Required<InsightVisualizationSpec>[];
-};
+export type SpecificInsightResult = Required<Omit<InsightInfo<PatternInfo>, 'score'>>;
 
 export type PatternInfo2InsightInfoProps = SpecificInsightProps & {
   patternInfos: PatternInfo[];


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
当无显著洞察时，不生成visualizationSpecs
![image](https://github.com/antvis/AVA/assets/71261480/d462c5ac-0404-4d55-ad0c-23b266882ef1)

