### PR TITLE
fix(ava/insight): modify the sign of regression line & format the mean i…

### DIFF
--- a/packages/ava/src/insight/chart/strategy/augmentedMarks/lowVariance.ts
+++ b/packages/ava/src/insight/chart/strategy/augmentedMarks/lowVariance.ts
@@ -1,17 +1,18 @@
-import { Mark } from '@antv/g2';
+import { LineMark, Mark } from '@antv/g2';
 
 import { LowVarianceInfo, InsightInfo } from '../../../types';
 import { lineMarkStrategy } from '../commonMarks';
 import { insight2ChartStrategy } from '../chart';
 import { LowVarianceMark } from '../../types';
 import { augmentedMarks2Marks } from '../../utils';
+import { dataFormat } from '../../../../utils';
 
 export const lowVarianceAugmentedMarkStrategy = (insight: InsightInfo<LowVarianceInfo>): LowVarianceMark[] => {
   const { patterns } = insight;
   const marks: LowVarianceMark[] = [];
   patterns.forEach((pattern) => {
     const { mean } = pattern;
-    const meanLineMark = lineMarkStrategy({ y: mean }, { label: `mean: ${mean}` });
+    const meanLineMark = lineMarkStrategy({ y: mean }, { label: `mean: ${dataFormat(mean)}` }) as LineMark;
     marks.push({
       meanLine: [meanLineMark],
     });

--- a/packages/ava/src/insight/chart/strategy/augmentedMarks/trend.ts
+++ b/packages/ava/src/insight/chart/strategy/augmentedMarks/trend.ts
@@ -4,6 +4,7 @@ import { lineMarkStrategy } from '../commonMarks';
 import { insight2ChartStrategy } from '../chart';
 import { InsightInfo, TrendInfo } from '../../../types';
 import { TrendMark } from '../../types';
+import { dataFormat } from '../../../../utils';
 
 export const trendAugmentedMarksStrategy = (insight: InsightInfo<TrendInfo>): TrendMark[] => {
   const {
@@ -28,7 +29,10 @@ export const trendAugmentedMarksStrategy = (insight: InsightInfo<TrendInfo>): Tr
 
   const lineData = points.map((point) => ({ x: point[0], y: point[1] }));
 
-  const regressionLineMark = lineMarkStrategy({ points: lineData }, { label: `y=${m.toFixed(2)}x+${c.toFixed(2)}` });
+  const regressionLineMark = lineMarkStrategy(
+    { points: lineData },
+    { label: `y=${dataFormat(m)}x${c < 0 ? '' : '+'}${dataFormat(c)}` }
+  );
 
   return [
     {


### PR DESCRIPTION
…n lowVarianceMark

### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
1: 修复回归线方程符号错误
![image](https://github.com/antvis/AVA/assets/71261480/fe4550e8-7ad0-4386-baba-83d35689065a)

2: 低方差均值格式化
![image](https://github.com/antvis/AVA/assets/71261480/3b4315e7-50e5-404d-aac1-429fecd59c55)
