### PR TITLE
fix(insight): 修复 同时命中 Integer 与 Date 类型时，死循环问题

### DIFF
--- a/packages/ava/src/data/analysis/field/index.ts
+++ b/packages/ava/src/data/analysis/field/index.ts
@@ -319,7 +319,7 @@ export function analyzeField(
         restNotNullArray = restNotNullArray.filter((item) => !isDateString(item));
       } else if (item === 'integer') {
         meta.integer = analyzeField(
-          restNotNullArray.filter((item) => isIntegerString(item)),
+          restNotNullArray.filter((item) => isIntegerString(item) && !isDateString(item)),
           strictDatePattern
         ) as NumberFieldInfo;
         restNotNullArray = restNotNullArray.filter((item) => !isIntegerString(item));


### PR DESCRIPTION
当数据是 ["32", "1980", "43" ] 会死循环

### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos
