### PR TITLE
fix(ava-react/ntv): fix ntv default text

### DIFF
--- a/packages/ava-react/package.json
+++ b/packages/ava-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/ava-react",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "React components of AVA.",
   "author": {
     "name": "AntV",

--- a/packages/ava-react/src/NarrativeTextVis/phrases/Phrase.tsx
+++ b/packages/ava-react/src/NarrativeTextVis/phrases/Phrase.tsx
@@ -188,5 +188,5 @@ export const Phrase: React.FC<PhraseProps> = ({
     return <>{renderPhraseByDescriptor({ spec: phrase, descriptor, themeStyles, events })}</>;
   }
 
-  return !isEmpty(events) ? <span {...eventProps}>defaultText</span> : defaultText;
+  return !isEmpty(events) ? <span {...eventProps}>{defaultText}</span> : defaultText;
 };


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->
defaultText 取值错误，应该取变量值
<img width="157" alt="Screenshot 2024-03-12 at 8 07 16 PM" src="https://github.com/antvis/AVA/assets/16997933/13a70d71-9e4c-4b33-b2f9-4c77e67b1966">

