### PR TITLE
fix(ava/data): fix the infinite loop issue in analyzeField

### DIFF
--- a/packages/ava/__tests__/unit/data/analysis/field/index.test.ts
+++ b/packages/ava/__tests__/unit/data/analysis/field/index.test.ts
@@ -443,3 +443,17 @@ test('date cols not boolean', () => {
   expect(d.minimum).toBe('2019-01-01');
   expect(d.maximum).toBe('2019-01-02');
 });
+
+test('recommendation hitting both float and Date types', () => {
+  const data = ['7007093.11', '2074.6'];
+  const d = analyzeField(data);
+  expect(d.type).toBe('mixed');
+  expect(d.recommendation).toBe('float');
+});
+
+test('recommendation hitting both integer and Date types', () => {
+  const data = ['32', '1980'];
+  const d = analyzeField(data);
+  expect(d.type).toBe('mixed');
+  expect(d.recommendation).toBe('integer');
+});

--- a/packages/ava/src/data/analysis/field/index.ts
+++ b/packages/ava/src/data/analysis/field/index.ts
@@ -277,7 +277,7 @@ export function analyzeField(
       }
       break;
     case 2:
-      if (types.includes('integer') && types.includes('float')) {
+      if ((types.includes('integer') || types.includes('date')) && types.includes('float')) {
         recommendation = 'float';
         break;
       }
@@ -325,7 +325,7 @@ export function analyzeField(
         restNotNullArray = restNotNullArray.filter((item) => !isIntegerString(item));
       } else if (item === 'float') {
         meta.float = analyzeField(
-          restNotNullArray.filter((item) => isFloatString(item)),
+          restNotNullArray.filter((item) => isFloatString(item) && !isDateString(item)),
           strictDatePattern
         ) as NumberFieldInfo;
         restNotNullArray = restNotNullArray.filter((item) => !isFloatString(item));

--- a/packages/ava/src/data/analysis/field/index.ts
+++ b/packages/ava/src/data/analysis/field/index.ts
@@ -286,8 +286,10 @@ export function analyzeField(
         const data = list.filter((item) => item !== null);
         if (data.map((num) => `${num}`).every((str) => isDateString(str))) {
           recommendation = 'date';
-          break;
+        } else {
+          recommendation = 'integer';
         }
+        break;
       }
       recommendation = 'string';
       break;


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

YYYY.M 格式的数据也会被识别为 日期。导致 某数值列 的推荐类型 有float和date，出现死循环
![image](https://github.com/antvis/AVA/assets/71261480/f68ee246-88cf-490e-9843-9b4aff878982)

