### PR TITLE
fix(visualization): support non-array analysis data in chart type adv…

### DIFF
--- a/src/ava.ts
+++ b/src/ava.ts
@@ -23,6 +23,17 @@ import type { AVAConfig, LLMConfig, DatasetInfo, AnalysisResponse, SuggestResult
 const DEFAULT_SQL_THRESHOLD = 10 * 1024; // 10KB
 
 /**
+ * Check if analysis result has meaningful data for visualization.
+ * Accepts arrays (non-empty), objects (non-empty), and non-null/non-undefined primitives.
+ */
+function hasData(data: unknown): boolean {
+  if (data == null) return false;
+  if (Array.isArray(data)) return data.length > 0;
+  if (typeof data === 'object') return Object.keys(data).length > 0;
+  return true;
+}
+
+/**
  * Main AVA class for AI-native visual analytics
  */
 export class AVA {
@@ -108,7 +119,7 @@ export class AVA {
       throw new Error('No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).');
     }
 
-    let analysisData: any[] = [];
+    let analysisData: any = null;
     let analysisCode: string | undefined;
     let analysisSql: string | undefined;
 
@@ -117,7 +128,7 @@ export class AVA {
       const schema = await this.sqliteStore.getSchema();
       const sql = await generateSQL(this.llmConfig, schema, query);
       analysisSql = sql;
-      
+
       try {
         analysisData = await this.sqliteStore.query(sql);
       } catch (error) {
@@ -151,12 +162,10 @@ export class AVA {
     let visualizationHTML: string | undefined;
     let visualizationSyntax: string | undefined;
     try {
-      // adviseChartType now handles both intent detection and chart selection
-      // Returns null if no visualization intent detected
+      // adviseChartType uses describeData which handles any data format
       const chartType = await adviseChartType(query, analysisData, this.llmConfig);
-      
-      if (chartType && analysisData.length > 0) {
-        // generateVisualizationHTML now combines syntax generation and HTML generation
+      if (chartType && hasData(analysisData)) {
+        // generateVisualizationHTML uses JSON.stringify which handles any JSON-serializable data
         const result = await generateVisualizationHTML(chartType, analysisData, query, this.llmConfig);
         visualizationSyntax = result.syntax;
         visualizationHTML = result.html;
@@ -167,7 +176,7 @@ export class AVA {
       // eslint-disable-next-line no-console
       console.warn('Failed to generate visualization:', errorMessage);
     }
-    
+
     return {
       text: summary,
       data: analysisData,

--- a/src/ava.ts
+++ b/src/ava.ts
@@ -119,7 +119,7 @@ export class AVA {
       throw new Error('No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).');
     }
 
-    let analysisData: any = null;
+    let analysisData: any = undefined;
     let analysisCode: string | undefined;
     let analysisSql: string | undefined;
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -113,32 +113,14 @@ export function formatDatasetInfo(info: DatasetInfo): string {
 }
 
 /**
- * Generate a human-readable data description for LLM context.
- * Supports arrays, objects (e.g. {labels, datasets}), strings, and primitives.
- * Unlike extractMetadata which requires flat object arrays, this handles any data format.
+ * Describe non-array data formats for LLM context.
+ * Handles objects (chart data patterns, generic), strings, and primitives.
  */
-export function describeData(data: unknown): string {
-  // Array of flat objects — use the existing metadata pipeline
-  if (Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && data[0] !== null) {
-    try {
-      const metadata = extractMetadata(data as any[]);
-      return formatDatasetInfo(metadata);
-    } catch {
-      // Fallback to raw description if metadata extraction fails
-    }
-  }
-
-  // Array of primitives
-  if (Array.isArray(data)) {
-    if (data.length === 0) return 'Dataset Info:\n- Empty dataset (0 rows)';
-    const sample = data.slice(0, 5).map(v => JSON.stringify(v)).join(', ');
-    return `Dataset Info:\n- Type: array of ${typeof data[0]}\n- Length: ${data.length}\n- Sample: ${sample}`;
-  }
-
-  // Object: { labels, datasets } pattern
+export function formatDatasetInfoWithNonArray(data: unknown): string {
   if (typeof data === 'object' && data !== null) {
     const obj = data as Record<string, unknown>;
 
+    // { labels, datasets } pattern — common chart data format
     if (Array.isArray(obj.labels) && Array.isArray(obj.datasets)) {
       const datasetSummaries = (obj.datasets as Array<Record<string, unknown>>).map((ds, i) => {
         const label = typeof ds.label === 'string' ? ds.label : `series-${i + 1}`;
@@ -157,30 +139,18 @@ export function describeData(data: unknown): string {
 
     // Generic object — describe keys and types
     const keys = Object.keys(obj);
-    const fieldDescs = keys.map(k => {
+    const fieldDesc = keys.map((k) => {
       const v = obj[k];
       const type = Array.isArray(v) ? `array[${v.length}]` : typeof v;
       const sample = typeof v === 'string' ? `"${v.slice(0, 30)}"` : JSON.stringify(v)?.slice(0, 50);
       return `  - ${k} (${type}): ${sample}`;
     });
-    return [
-      'Dataset Info:',
-      '- Type: object',
-      `- Fields (${keys.length}):`,
-      ...fieldDescs,
-    ].join('\n');
+    return ['Dataset Info:', '- Type: object', `- Fields (${keys.length}):`, ...fieldDesc].join('\n');
   }
 
-  // String
   if (typeof data === 'string') {
-    return [
-      'Dataset Info:',
-      '- Type: string',
-      `- Length: ${data.length} characters`,
-      `- Preview: ${data}`,
-    ].join('\n');
+    return ['Dataset Info:', '- Type: string', `- Length: ${data.length} characters`, `- Preview: ${data}`].join('\n');
   }
 
-  // Fallback for number, boolean, null, undefined
   return `Dataset Info:\n- Type: ${data === null ? 'null' : typeof data}\n- Value: ${String(data)}`;
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -15,23 +15,23 @@ export { loadText } from './text';
  */
 function inferFieldType(values: any[]): 'number' | 'string' | 'date' | 'boolean' {
   const nonNullValues = values.filter(v => v != null && v !== '');
-  
+
   if (nonNullValues.length === 0) return 'string';
-  
+
   // Check if all values are numbers
   const allNumbers = nonNullValues.every(v => typeof v === 'number' || !Number.isNaN(Number(v)));
   if (allNumbers) return 'number';
-  
+
   // Check if all values are booleans
-  const allBooleans = nonNullValues.every(v => 
-    typeof v === 'boolean' || 
-    v === 'true' || 
+  const allBooleans = nonNullValues.every(v =>
+    typeof v === 'boolean' ||
+    v === 'true' ||
     v === 'false' ||
     v === 'TRUE' ||
     v === 'FALSE'
   );
   if (allBooleans) return 'boolean';
-  
+
   // Check if values look like dates
   const allDates = nonNullValues.every(v => {
     if (typeof v === 'string') {
@@ -41,7 +41,7 @@ function inferFieldType(values: any[]): 'number' | 'string' | 'date' | 'boolean'
     return false;
   });
   if (allDates) return 'date';
-  
+
   return 'string';
 }
 
@@ -57,15 +57,15 @@ export function extractMetadata(data: any[]): DatasetInfo {
       sizeInBytes: 0,
     };
   }
-  
+
   const fields: FieldMetadata[] = [];
   const columns = Object.keys(data[0]);
-  
+
   for (const col of columns) {
     const values = data.map(row => row[col]);
     const nonNullValues = values.filter(v => v != null && v !== '');
     const uniqueValues = new Set(values);
-    
+
     fields.push({
       name: col,
       type: inferFieldType(values),
@@ -74,11 +74,11 @@ export function extractMetadata(data: any[]): DatasetInfo {
       nullCount: values.length - nonNullValues.length,
     });
   }
-  
+
   // Estimate size in bytes (works in both Node.js and browser)
   const jsonString = JSON.stringify(data);
   const sizeInBytes = new TextEncoder().encode(jsonString).length;
-  
+
   return {
     rowCount: data.length,
     columnCount: columns.length,
@@ -96,7 +96,7 @@ export function formatDatasetInfo(info: DatasetInfo): string {
   result += `- Columns: ${info.columnCount}\n`;
   result += `- Size: ${(info.sizeInBytes / 1024).toFixed(2)} KB\n`;
   result += '\nFields:\n';
-  
+
   for (const field of info.fields) {
     result += `- ${field.name} (${field.type}): `;
     result += `${field.uniqueCount} unique values`;
@@ -108,6 +108,79 @@ export function formatDatasetInfo(info: DatasetInfo): string {
     }
     result += '\n';
   }
-  
+
   return result;
+}
+
+/**
+ * Generate a human-readable data description for LLM context.
+ * Supports arrays, objects (e.g. {labels, datasets}), strings, and primitives.
+ * Unlike extractMetadata which requires flat object arrays, this handles any data format.
+ */
+export function describeData(data: unknown): string {
+  // Array of flat objects — use the existing metadata pipeline
+  if (Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && data[0] !== null) {
+    try {
+      const metadata = extractMetadata(data as any[]);
+      return formatDatasetInfo(metadata);
+    } catch {
+      // Fallback to raw description if metadata extraction fails
+    }
+  }
+
+  // Array of primitives
+  if (Array.isArray(data)) {
+    if (data.length === 0) return 'Dataset Info:\n- Empty dataset (0 rows)';
+    const sample = data.slice(0, 5).map(v => JSON.stringify(v)).join(', ');
+    return `Dataset Info:\n- Type: array of ${typeof data[0]}\n- Length: ${data.length}\n- Sample: ${sample}`;
+  }
+
+  // Object: { labels, datasets } pattern
+  if (typeof data === 'object' && data !== null) {
+    const obj = data as Record<string, unknown>;
+
+    if (Array.isArray(obj.labels) && Array.isArray(obj.datasets)) {
+      const datasetSummaries = (obj.datasets as Array<Record<string, unknown>>).map((ds, i) => {
+        const label = typeof ds.label === 'string' ? ds.label : `series-${i + 1}`;
+        const len = Array.isArray(ds.data) ? ds.data.length : 0;
+        const sample = Array.isArray(ds.data) ? ds.data.slice(0, 3).join(', ') : '';
+        return `  - ${label}: [${len} values]${sample ? ` sample: ${sample}` : ''}`;
+      });
+      return [
+        'Dataset Info:',
+        '- Type: chart data with labels and datasets',
+        `- Labels (${(obj.labels as unknown[]).length}): ${(obj.labels as unknown[]).slice(0, 5).join(', ')}`,
+        '- Datasets:',
+        ...datasetSummaries,
+      ].join('\n');
+    }
+
+    // Generic object — describe keys and types
+    const keys = Object.keys(obj);
+    const fieldDescs = keys.map(k => {
+      const v = obj[k];
+      const type = Array.isArray(v) ? `array[${v.length}]` : typeof v;
+      const sample = typeof v === 'string' ? `"${v.slice(0, 30)}"` : JSON.stringify(v)?.slice(0, 50);
+      return `  - ${k} (${type}): ${sample}`;
+    });
+    return [
+      'Dataset Info:',
+      '- Type: object',
+      `- Fields (${keys.length}):`,
+      ...fieldDescs,
+    ].join('\n');
+  }
+
+  // String
+  if (typeof data === 'string') {
+    return [
+      'Dataset Info:',
+      '- Type: string',
+      `- Length: ${data.length} characters`,
+      `- Preview: ${data}`,
+    ].join('\n');
+  }
+
+  // Fallback for number, boolean, null, undefined
+  return `Dataset Info:\n- Type: ${data === null ? 'null' : typeof data}\n- Value: ${String(data)}`;
 }

--- a/src/visualization/advisor.ts
+++ b/src/visualization/advisor.ts
@@ -5,7 +5,7 @@
 import { generateText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 
-import { extractMetadata, formatDatasetInfo } from '../data';
+import { describeData } from '../data';
 
 import type { LLMConfig, ChartType } from '../types';
 
@@ -15,7 +15,7 @@ import type { LLMConfig, ChartType } from '../types';
  */
 export async function adviseChartType(
   query: string,
-  data: any[],
+  data: unknown,
   llmConfig: LLMConfig
 ): Promise<ChartType | null> {
   const openai = createOpenAI({
@@ -23,9 +23,7 @@ export async function adviseChartType(
     baseURL: llmConfig.baseURL,
   });
 
-  // Use existing metadata extraction functionality
-  const metadata = extractMetadata(data);
-  const dataInfo = formatDatasetInfo(metadata);
+  const dataInfo = describeData(data);
 
   const prompt = `你是一个图表推荐专家。根据用户的查询和数据特征，判断是否需要可视化，如果需要则推荐最合适的图表类型。
 
@@ -59,7 +57,7 @@ ${dataInfo}
 - **功能**: 占比、成分分析
 - **适用场景**: 显示组成部分占整体的比例，强调某部分在整体中的占比
 - **数据要求**: 需要一个分类字段和一个数值字段，分类应构成一个整体
-- **不适用场景**: 
+- **不适用场景**:
   - 变量相互独立不构成整体
   - 不能表现趋势
   - 数值接近时难以分辨
@@ -165,23 +163,23 @@ ${dataInfo}
   });
 
   const chartType = text.trim().toLowerCase();
-  
+
   // Check if no visualization intent
   if (chartType === 'none' || chartType === '否' || chartType === 'no') {
     return null;
   }
-  
+
   // Validate that the chart type is valid
   const validChartTypes: ChartType[] = [
     'line', 'column', 'bar', 'pie', 'area', 'scatter', 'dual-axes',
     'histogram', 'boxplot', 'radar', 'funnel', 'waterfall', 'liquid',
     'word-cloud', 'violin', 'venn', 'treemap', 'sankey', 'table', 'summary',
   ];
-  
+
   if (validChartTypes.includes(chartType as ChartType)) {
     return chartType as ChartType;
   }
-  
+
   // If invalid response but not explicitly "none", return null (no intent)
   return null;
 }

--- a/src/visualization/advisor.ts
+++ b/src/visualization/advisor.ts
@@ -5,7 +5,7 @@
 import { generateText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 
-import { describeData } from '../data';
+import { formatDatasetInfoWithNonArray, extractMetadata, formatDatasetInfo } from '../data';
 
 import type { LLMConfig, ChartType } from '../types';
 
@@ -22,8 +22,7 @@ export async function adviseChartType(
     apiKey: llmConfig.apiKey,
     baseURL: llmConfig.baseURL,
   });
-
-  const dataInfo = describeData(data);
+  const dataInfo = Array.isArray(data) ? formatDatasetInfo(extractMetadata(data)) : formatDatasetInfoWithNonArray(data);
 
   const prompt = `你是一个图表推荐专家。根据用户的查询和数据特征，判断是否需要可视化，如果需要则推荐最合适的图表类型。
 

--- a/src/visualization/generator.ts
+++ b/src/visualization/generator.ts
@@ -14,7 +14,7 @@ import type { LLMConfig, ChartType } from '../types';
  */
 export async function generateVisualizationHTML(
   chartType: ChartType,
-  data: any[],
+  data: any,
   query: string,
   llmConfig: LLMConfig
 ): Promise<{ syntax: string; html: string }> {


### PR DESCRIPTION
- 扩展了 LLM 返回数据的校验方式（describeData 函数，原来只接受扁平数据是 extractMetadata 函数处理）
- 在 ava.ts 中添加 hasData 保护，以替换在非数组类型上会失败的数据检查