### PR TITLE
feat(site): add Excel file support and fix HTML markdown markers

### DIFF
--- a/site/components/DataImport.tsx
+++ b/site/components/DataImport.tsx
@@ -66,6 +66,9 @@ const DataImport: React.FC<DataImportProps> = ({ avaInstance, onDataLoaded, isIn
 
     try {
       const fileName = file.name.toLowerCase();
+      if (file.size > 25 * 1024 * 1024) {
+        throw new Error('File size exceeds 25MB limit');
+      }
       const isExcel = fileName.endsWith('.xlsx') || fileName.endsWith('.xls');
 
       let parsedData: DataRow[];

--- a/site/components/DataImport.tsx
+++ b/site/components/DataImport.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { AVA } from '@antv/ava';
 import type { DataRow } from './types';
-import { parseCSV, loadAppState, saveAppState } from './utils';
+import { parseCSV, parseExcel, loadAppState, saveAppState } from './utils';
 
 interface DataImportProps {
   avaInstance: AVA | null;
@@ -40,10 +40,10 @@ const DataImport: React.FC<DataImportProps> = ({ avaInstance, onDataLoaded, isIn
       // Use the global AVA instance's loadText to extract structured data from text
       // The loadText API returns the loaded structured data directly
       const data = await avaInstance.loadText(textInput);
-      
+
       // Save to localStorage
       saveAppState({ data, textInput });
-      
+
       onDataLoaded(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to extract data');
@@ -65,25 +65,28 @@ const DataImport: React.FC<DataImportProps> = ({ avaInstance, onDataLoaded, isIn
     setError(null);
 
     try {
-      const content = await file.text();
-      
-      // Parse CSV in browser
-      const parsedData = parseCSV(content);
-      
-      if (parsedData.length === 0) {
-        throw new Error('No valid data found in CSV file');
+      const fileName = file.name.toLowerCase();
+      const isExcel = fileName.endsWith('.xlsx') || fileName.endsWith('.xls');
+
+      let parsedData: DataRow[];
+
+      if (isExcel) {
+        const arrayBuffer = await file.arrayBuffer();
+        parsedData = parseExcel(arrayBuffer);
+      } else {
+        const content = await file.text();
+        parsedData = parseCSV(content);
       }
 
-      // Use the global AVA instance's loadObject to load the parsed data
-      // The loadObject API returns the loaded structured data directly
+      if (parsedData.length === 0) {
+        throw new Error(`No valid data found in ${isExcel ? 'Excel' : 'CSV'} file`);
+      }
+
       const data = await avaInstance.loadObject(parsedData);
-      
-      // Save to localStorage (clear textInput since we're using file)
       saveAppState({ data, textInput: '' });
-      
       onDataLoaded(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to parse CSV');
+      setError(err instanceof Error ? err.message : 'Failed to parse file');
     } finally {
       setIsLoading(false);
       if (fileInputRef.current) {

--- a/site/components/utils.ts
+++ b/site/components/utils.ts
@@ -91,7 +91,7 @@ export const parseExcel = (arrayBuffer: ArrayBuffer): DataRow[] => {
 
   if (jsonData.length < 2) return [];
 
-  const headers = (jsonData[0] as string[]).map(h => String(h).trim());
+  const headers = (jsonData[0] as any[]).map(h => (h !== null && h !== undefined ? String(h).trim() : ''));
   const result: DataRow[] = [];
 
   for (let i = 1; i < jsonData.length; i++) {

--- a/site/components/utils.ts
+++ b/site/components/utils.ts
@@ -1,4 +1,5 @@
 import type { LLMConfig } from '@antv/ava';
+import * as XLSX from 'xlsx';
 
 // Default LLM config
 export const DEFAULT_LLM_CONFIG: LLMConfig = {
@@ -13,7 +14,7 @@ export const loadLLMConfig = (): LLMConfig => {
   if (typeof window === 'undefined') {
     return DEFAULT_LLM_CONFIG;
   }
-  
+
   try {
     const saved = localStorage.getItem('ava-llm-config');
     if (saved) {
@@ -48,7 +49,7 @@ export const loadAppState = (): Partial<AppState> => {
   if (typeof window === 'undefined') {
     return {};
   }
-  
+
   try {
     const saved = localStorage.getItem('ava-app-state');
     if (saved) {
@@ -82,20 +83,54 @@ export const saveAppState = (state: Partial<AppState>) => {
   }
 };
 
+// Parse Excel file (.xlsx, .xls) to DataRow array
+export const parseExcel = (arrayBuffer: ArrayBuffer): DataRow[] => {
+  const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+  const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+  const jsonData = XLSX.utils.sheet_to_json(firstSheet, { header: 1 }) as unknown[][];
+
+  if (jsonData.length < 2) return [];
+
+  const headers = (jsonData[0] as string[]).map(h => String(h).trim());
+  const result: DataRow[] = [];
+
+  for (let i = 1; i < jsonData.length; i++) {
+    const row = jsonData[i];
+    if (!row || row.length === 0) continue;
+
+    const rowData: DataRow = {};
+    headers.forEach((header, index) => {
+      const val = row[index];
+      if (val === undefined || val === null) {
+        rowData[header] = '';
+      } else if (typeof val === 'number') {
+        rowData[header] = val;
+      } else {
+        const strVal = String(val).trim();
+        const num = Number(strVal);
+        rowData[header] = !isNaN(num) && strVal !== '' ? num : strVal;
+      }
+    });
+    result.push(rowData);
+  }
+
+  return result;
+};
+
 // RFC 4180 compliant CSV parser for browser
 export const parseCSV = (csvContent: string): DataRow[] => {
   const lines = csvContent.trim().split('\n');
   if (lines.length < 2) return [];
-  
+
   // Parse a CSV line handling quoted values with commas
   const parseLine = (line: string): string[] => {
     const result: string[] = [];
     let current = '';
     let inQuotes = false;
-    
+
     for (let i = 0; i < line.length; i++) {
       const char = line[i];
-      
+
       if (char === '"') {
         if (inQuotes && line[i + 1] === '"') {
           // Escaped quote
@@ -115,10 +150,10 @@ export const parseCSV = (csvContent: string): DataRow[] => {
     result.push(current.trim());
     return result;
   };
-  
+
   const headers = parseLine(lines[0]).map(h => h.replace(/^["']|["']$/g, ''));
   const data: DataRow[] = [];
-  
+
   for (let i = 1; i < lines.length; i++) {
     const values = parseLine(lines[i]).map(v => v.replace(/^["']|["']$/g, ''));
     if (values.length === headers.length) {
@@ -132,6 +167,6 @@ export const parseCSV = (csvContent: string): DataRow[] => {
       data.push(row);
     }
   }
-  
+
   return data;
 };

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,8 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^24.10.10",

--- a/src/visualization/generator.ts
+++ b/src/visualization/generator.ts
@@ -439,7 +439,16 @@ title "2024 Q1 Sales Report"
     prompt,
   });
 
-  const html = text.trim();
+  // Remove markdown code block markers if present
+  let html = text.trim();
+  if (html.startsWith('```html')) {
+    html = html.slice(7).trim();
+  } else if (html.startsWith('```')) {
+    html = html.slice(3).trim();
+  }
+  if (html.endsWith('```')) {
+    html = html.slice(0, -3).trim();
+  }
 
   // Extract GPT-Vis syntax from the HTML
   // Look for the visSyntax variable assignment in template literal

--- a/src/visualization/generator.ts
+++ b/src/visualization/generator.ts
@@ -440,15 +440,7 @@ title "2024 Q1 Sales Report"
   });
 
   // Remove markdown code block markers if present
-  let html = text.trim();
-  if (html.startsWith('```html')) {
-    html = html.slice(7).trim();
-  } else if (html.startsWith('```')) {
-    html = html.slice(3).trim();
-  }
-  if (html.endsWith('```')) {
-    html = html.slice(0, -3).trim();
-  }
+  let html = text.trim().replace(/^```(?:html)?\s*/i, '').replace(/\s*```$/, '').trim();
 
   // Extract GPT-Vis syntax from the HTML
   // Look for the visSyntax variable assignment in template literal


### PR DESCRIPTION
修复：
  - 去除 LLM 生成的 HTML 中的 markdown 代码块标记（去除开头的 ```html ```、去除结尾的 ```）
 
<img width="1100" height="473" alt="image" src="https://github.com/user-attachments/assets/35ea67ea-26ad-4e1d-9277-868cacc31ff2" />

<img width="1074" height="438" alt="image" src="https://github.com/user-attachments/assets/7df2d282-9a90-4da2-aa4b-83cf252491de" />

site新增：                                                                                                                                                       
  - 支持上传并解析 Excel 文件（.xlsx/.xls）
  - 根据文件扩展名自动选择 CSV 或 Excel 解析器                                                                                                                          
  - 添加 xlsx 库用于 Excel 文件解析
 
<img width="545" height="247" alt="image" src="https://github.com/user-attachments/assets/b9f5e884-58a4-4bc5-a428-66533584e7f6" />

                                                                                                                                                                        
