### PR TITLE
feat: replace iframe-based chart rendering with @antv/gpt-vis React c…

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,53 +1,55 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from 'next';
+import './globals.css';
 
 export const metadata: Metadata = {
   title: 'AVA - AI-Native Visual Analytics | AntV',
-  description: 'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
-  keywords: 'AVA, visual analytics, AI-native, LLM, data visualization, natural language, data analysis, AntV, chart generation',
+  description:
+    'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
+  keywords:
+    'AVA, visual analytics, AI-native, LLM, data visualization, natural language, data analysis, AntV, chart generation',
   authors: [{ name: 'AntV' }],
   openGraph: {
     type: 'website',
     url: 'https://ava.antv.vision/',
     title: 'AVA - AI-Native Visual Analytics | AntV',
-    description: 'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
-    images: [{
-      url: 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*yOHIQ48aRwgAAAAAAAAAAAAADmJ7AQ/original',
-    }],
+    description:
+      'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
+    images: [
+      {
+        url: 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*yOHIQ48aRwgAAAAAAAAAAAAADmJ7AQ/original',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'AVA - AI-Native Visual Analytics | AntV',
-    description: 'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
+    description:
+      'AVA is a technology framework designed for more convenient visual analytics. AI-native, automated visual analytics with natural language queries, LLM-powered analysis, and smart data handling.',
     images: ['https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*yOHIQ48aRwgAAAAAAAAAAAAADmJ7AQ/original'],
   },
   icons: {
     icon: 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*FBLnQIAzx6cAAAAAQDAAAAgAemJ7AQ/original',
   },
-}
+};
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <head>
-        <script dangerouslySetInnerHTML={{
-          __html: `
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
             // Buffer polyfill for browser compatibility with csv-parse
             window.Buffer = window.Buffer || {
               isBuffer: function() { return false; },
               from: function(str) { return new TextEncoder().encode(str); },
               alloc: function(size) { return new Uint8Array(size); },
             };
-          `
-        }} />
+          `,
+          }}
+        />
       </head>
-      <body className="min-h-screen bg-[#f8fbfc]">
-        {children}
-      </body>
+      <body className="min-h-screen bg-[#f8fbfc]">{children}</body>
     </html>
-  )
+  );
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{
           __html: `

--- a/site/components/GPTVisRenderer.tsx
+++ b/site/components/GPTVisRenderer.tsx
@@ -14,32 +14,35 @@ const GPTVisRenderer: React.FC<GPTVisRendererProps> = ({ syntax, width, height, 
   const containerRef = useRef<HTMLDivElement>(null);
   const instanceRef = useRef<GPTVis | null>(null);
 
+  // Mount: create instance once. Unmount: destroy.
   useEffect(() => {
-    if (!containerRef.current || !syntax) return;
+    if (!containerRef.current) return;
+
+    const instance = new GPTVis({
+      container: containerRef.current,
+      width,
+      height,
+      theme: 'light',
+      wrapper: true,
+    });
+    instanceRef.current = instance;
+
+    return () => {
+      instance.destroy();
+      instanceRef.current = null;
+    };
+  }, []);
+
+  // Update: re-render when syntax or dimensions change.
+  useEffect(() => {
+    if (!instanceRef.current || !syntax) return;
 
     try {
-      if (!instanceRef.current) {
-        instanceRef.current = new GPTVis({
-          container: containerRef.current,
-          width,
-          height,
-          theme: 'light',
-          wrapper: true,
-        });
-      }
-
       instanceRef.current.render(syntax);
       onRender?.();
     } catch (err) {
       onError?.(err instanceof Error ? err : new Error(String(err)));
     }
-
-    return () => {
-      if (instanceRef.current) {
-        instanceRef.current.destroy();
-        instanceRef.current = null;
-      }
-    };
   }, [syntax, width, height]);
 
   return <div ref={containerRef} className="w-full h-full" />;

--- a/site/components/GPTVisRenderer.tsx
+++ b/site/components/GPTVisRenderer.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { GPTVis } from '@antv/gpt-vis';
+
+interface GPTVisRendererProps {
+  syntax: string;
+  width?: number;
+  height?: number;
+  onRender?: () => void;
+  onError?: (error: Error) => void;
+}
+
+const GPTVisRenderer: React.FC<GPTVisRendererProps> = ({ syntax, width, height, onRender, onError }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const instanceRef = useRef<GPTVis | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !syntax) return;
+
+    try {
+      if (!instanceRef.current) {
+        instanceRef.current = new GPTVis({
+          container: containerRef.current,
+          width,
+          height,
+          theme: 'light',
+          wrapper: true,
+        });
+      }
+
+      instanceRef.current.render(syntax);
+      onRender?.();
+    } catch (err) {
+      onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
+
+    return () => {
+      if (instanceRef.current) {
+        instanceRef.current.destroy();
+        instanceRef.current = null;
+      }
+    };
+  }, [syntax, width, height]);
+
+  return <div ref={containerRef} className="w-full h-full" />;
+};
+
+export default GPTVisRenderer;

--- a/site/components/Visualization.tsx
+++ b/site/components/Visualization.tsx
@@ -1,43 +1,18 @@
-'use client'
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+'use client';
+import React, { useState, useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { AVA } from '@antv/ava';
 import type { AnalysisResponse } from '@antv/ava';
 import type { DataRow } from './types';
 import { loadAppState, saveAppState } from './utils';
+import GPTVisRenderer from './GPTVisRenderer';
 
 interface VisualizationProps {
   avaInstance: AVA | null;
   data: DataRow[];
   isInitialized: boolean;
 }
-
-// Helper function to download HTML
-const downloadHTML = (html: string) => {
-  const blob = new Blob([html], { type: 'text/html;charset=utf-8;' });
-  const link = document.createElement('a');
-  const url = URL.createObjectURL(blob);
-  
-  link.setAttribute('href', url);
-  link.setAttribute('download', `chart_${new Date().getTime()}.html`);
-  link.style.visibility = 'hidden';
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
-};
-
-// Helper function to copy HTML to clipboard
-const copyToClipboard = async (html: string): Promise<boolean> => {
-  try {
-    await navigator.clipboard.writeText(html);
-    return true;
-  } catch (err) {
-    console.error('Failed to copy:', err);
-    return false;
-  }
-};
 
 const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInitialized }) => {
   const [query, setQuery] = useState('');
@@ -46,9 +21,6 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
   const [result, setResult] = useState<AnalysisResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
-  const [isHoveringChart, setIsHoveringChart] = useState(false);
-  const [copySuccess, setCopySuccess] = useState(false);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Restore query and result from localStorage on mount
   useEffect(() => {
@@ -65,7 +37,7 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
 
   const handleGenerate = useCallback(async () => {
     if (!query.trim()) return;
-    
+
     if (!avaInstance) {
       setError('Please configure your LLM API key first. Click the LLM button in the header to set up.');
       return;
@@ -78,7 +50,7 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
       // Use the global AVA instance's analysis method to process the query
       const analysisResult = await avaInstance.analysis(query);
       setResult(analysisResult);
-      
+
       // Save to localStorage
       saveAppState({ query, analysisResult });
     } catch (err) {
@@ -111,61 +83,15 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
     }
   }, [avaInstance]);
 
-  // Update iframe content when visualization changes
-  useEffect(() => {
-    if (result?.visualizationHTML && iframeRef.current) {
-      const htmlContent = result.visualizationHTML; // Capture to maintain type narrowing
-      const iframe = iframeRef.current;
-      
-      // Handler to write content after iframe resets
-      const handleLoad = () => {
-        const doc = iframe.contentDocument;
-        if (doc) {
-          doc.open();
-          doc.write(htmlContent);
-          doc.close();
-        }
-        iframe.removeEventListener('load', handleLoad);
-      };
-      
-      // Listen for load event before resetting
-      iframe.addEventListener('load', handleLoad);
-      
-      // Reset iframe by setting src to about:blank to clear previous context
-      iframe.src = 'about:blank';
-      
-      // Cleanup function
-      return () => {
-        iframe.removeEventListener('load', handleLoad);
-      };
-    }
-  }, [result?.visualizationHTML]);
-
   // Get analysis code (JavaScript or SQL)
   const analysisCode = result?.code || result?.sql;
-
-  // Handle copy action
-  const handleCopy = async () => {
-    if (result?.visualizationHTML) {
-      const success = await copyToClipboard(result.visualizationHTML);
-      if (success) {
-        setCopySuccess(true);
-        setTimeout(() => setCopySuccess(false), 2000);
-      }
-    }
-  };
-
-  // Handle download action
-  const handleDownload = () => {
-    if (result?.visualizationHTML) {
-      downloadHTML(result.visualizationHTML);
-    }
-  };
 
   return (
     <div className="bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
       <div className="flex items-center gap-3 mb-5">
-        <span className="flex items-center justify-center w-6 h-6 bg-[#78d3f8]/20 text-[#78d3f8] text-sm font-semibold rounded-full">3</span>
+        <span className="flex items-center justify-center w-6 h-6 bg-[#78d3f8]/20 text-[#78d3f8] text-sm font-semibold rounded-full">
+          3
+        </span>
         <h2 className="text-lg font-semibold text-gray-800">Visualize with AI</h2>
       </div>
 
@@ -175,8 +101,8 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
           <input
             type="text"
             value={query}
-            onChange={e => setQuery(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleGenerate()}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleGenerate()}
             placeholder="Create a trend line comparing North America and Europe sales growth"
             className="w-full px-4 py-3 pr-12 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-[#78d3f8]/50 focus:border-[#78d3f8] transition-all text-sm"
             disabled={isLoading || isSuggesting}
@@ -190,11 +116,20 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
             {isSuggesting ? (
               <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
               </svg>
             ) : (
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                />
               </svg>
             )}
           </button>
@@ -208,7 +143,11 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
             <>
               <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
               </svg>
               Generating...
             </>
@@ -222,7 +161,11 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
       </div>
 
       {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm" role="alert" aria-live="assertive">
+        <div
+          className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm"
+          role="alert"
+          aria-live="assertive"
+        >
           {error}
         </div>
       )}
@@ -236,84 +179,41 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
             {analysisCode && (
               <button
                 onClick={() => setShowCode(!showCode)}
-                className={`p-1.5 rounded-lg transition-colors ${showCode ? 'bg-[#78d3f8]/20 text-[#78d3f8]' : 'hover:bg-gray-200 text-gray-500'}`}
+                className={`p-1.5 rounded-lg transition-colors ${
+                  showCode ? 'bg-[#78d3f8]/20 text-[#78d3f8]' : 'hover:bg-gray-200 text-gray-500'
+                }`}
                 title={showCode ? 'Hide code' : 'View code'}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                  />
                 </svg>
               </button>
             )}
           </div>
-          
+
           {/* Collapsible Code Block - Moved above summary text */}
           {showCode && analysisCode && (
             <div className="mb-4">
-              <h5 className="text-xs font-medium text-gray-500 mb-2">
-                {result?.sql ? 'SQL Query' : 'Analysis Code'}
-              </h5>
-              <pre className="p-4 bg-gray-900 text-gray-100 rounded-xl text-xs overflow-x-auto">
-                {analysisCode}
-              </pre>
+              <h5 className="text-xs font-medium text-gray-500 mb-2">{result?.sql ? 'SQL Query' : 'Analysis Code'}</h5>
+              <pre className="p-4 bg-gray-900 text-gray-100 rounded-xl text-xs overflow-x-auto">{analysisCode}</pre>
             </div>
           )}
-          
+
           <div className="text-sm text-gray-600 prose prose-sm max-w-none">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{result.text}</ReactMarkdown>
           </div>
         </div>
       )}
 
-      {/* Visualization Area - Only show when visualizationHTML exists */}
-      {result?.visualizationHTML && (
-        <div 
-          className="relative min-h-[400px] border-2 border-dashed border-[#78d3f8]/20 rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-white"
-          onMouseEnter={() => setIsHoveringChart(true)}
-          onMouseLeave={() => setIsHoveringChart(false)}
-        >
-          {/* Action buttons overlay */}
-          {isHoveringChart && (
-            <div className="absolute top-3 right-3 z-10 flex items-center gap-2 bg-white/90 backdrop-blur-sm rounded-lg shadow-lg p-1 border border-gray-200">
-              <button
-                onClick={handleCopy}
-                className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-gray-100 rounded-md transition-colors text-sm text-gray-700"
-                title="Copy HTML"
-              >
-                {copySuccess ? (
-                  <>
-                    <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    <span className="text-green-500">Copied!</span>
-                  </>
-                ) : (
-                  <>
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                    </svg>
-                    <span>Copy</span>
-                  </>
-                )}
-              </button>
-              <button
-                onClick={handleDownload}
-                className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-gray-100 rounded-md transition-colors text-sm text-gray-700"
-                title="Download HTML"
-              >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-                <span>Download</span>
-              </button>
-            </div>
-          )}
-          
-          <iframe
-            ref={iframeRef}
-            className="w-full h-[400px] border-0"
-            title="Visualization"
-            sandbox="allow-scripts allow-same-origin"
-          />
+      {/* Visualization Area - Only show when visualizationSyntax exists */}
+      {result?.visualizationSyntax && (
+        <div className="relative min-h-[400px] border-2 border-dashed border-[#78d3f8]/20 rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-white">
+          <GPTVisRenderer syntax={result.visualizationSyntax} />
         </div>
       )}
 
@@ -331,9 +231,7 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
                 <div className="w-8 h-[88px] bg-[#78d3f8] rounded-t-lg" />
               </div>
               {/* Sparkle icon */}
-              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl">
-                ✨
-              </div>
+              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl">✨</div>
             </div>
             <h3 className="text-lg font-medium text-gray-600 mb-2">Chart Preview</h3>
             <p className="text-sm text-center max-w-xs">

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@antv/ava": "file:..",
+    "@antv/gpt-vis": "^1.0.0",
     "@tailwindcss/postcss": "^4.1.18",
     "autoprefixer": "^10.4.24",
     "buffer": "^6.0.3",


### PR DESCRIPTION
<img width="1396" height="828" alt="image" src="https://github.com/user-attachments/assets/917e52c7-3296-48cd-ab34-3c8dab1c6b30" />
原先的渲染是使用iframe显然模型返回的 html 文件，现改成 GPT-Vis 组件，更加美观，并且使用 GPT-Vis 自带的下载，查看代码等功能