### PR TITLE
最新 - 给 AVA.analysis() 方法加入分步进度报告能力，并在 site 侧新增 AnalysisSteps UI 组件实现可视化展示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ temp.diff
 **/*/src/.umi-production
 **/*/src/.umi-test
 **/*/.env.local
+
+#pnpm-lock
+pnpm-lock.yaml

--- a/site/components/AnalysisSteps.tsx
+++ b/site/components/AnalysisSteps.tsx
@@ -118,7 +118,7 @@ export default function AnalysisSteps({ steps, collapsed }: AnalysisStepsProps) 
     <span className="flex items-center gap-2 text-sm">
       <DoneIcon />
       <span>
-        分析完成 · 共 {sorted.length} 步{totalDuration !== null && ` · 耗时 ${totalDuration.toFixed(1)}s`}
+        Analysis complete · {sorted.length} steps{totalDuration !== null && ` · ${totalDuration.toFixed(1)}s`}
       </span>
     </span>
   );
@@ -132,7 +132,7 @@ export default function AnalysisSteps({ steps, collapsed }: AnalysisStepsProps) 
         >
           {title}
           <span className="text-[#78d3f8] font-medium flex items-center gap-1">
-            展开
+            Expand
             <svg
               className="w-3 h-3"
               viewBox="0 0 24 24"
@@ -160,7 +160,7 @@ export default function AnalysisSteps({ steps, collapsed }: AnalysisStepsProps) 
             onClick={() => setForceExpanded(false)}
             className="text-xs text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-1 flex-shrink-0"
           >
-            收起
+            Collapse
             <svg
               className="w-3 h-3"
               viewBox="0 0 24 24"
@@ -209,7 +209,7 @@ export default function AnalysisSteps({ steps, collapsed }: AnalysisStepsProps) 
                       isExpanded ? 'text-[#78d3f8]' : 'text-gray-400 hover:text-[#78d3f8]'
                     }`}
                   >
-                    {isExpanded ? '收起' : '查看'}
+                    {isExpanded ? 'Collapse' : 'View'}
                     <svg
                       className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
                       viewBox="0 0 24 24"

--- a/site/components/AnalysisSteps.tsx
+++ b/site/components/AnalysisSteps.tsx
@@ -1,0 +1,247 @@
+'use client';
+import React, { useState, useMemo } from 'react';
+import type { AnalysisStep, StepStatus } from '@antv/ava';
+
+interface AnalysisStepsProps {
+  steps: AnalysisStep[];
+  collapsed: boolean;
+}
+
+function getStepTime(step: AnalysisStep, index: number, sorted: AnalysisStep[]): string | null {
+  if (step.status !== 'done') return null;
+  if (index === 0) return null;
+  const prevTimestamp = sorted[index - 1].timestamp;
+  const duration = (step.timestamp - prevTimestamp) / 1000;
+  if (duration <= 0) return null;
+  return `${duration.toFixed(1)}s`;
+}
+
+function DoneIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-green-500 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function RunningIcon() {
+  return (
+    <svg className="w-4 h-4 text-[#78d3f8] flex-shrink-0 animate-spin" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+function PendingIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-gray-300 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  );
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-red-500 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function StepIcon({ status }: { status: StepStatus }) {
+  switch (status) {
+    case 'done':
+      return <DoneIcon />;
+    case 'running':
+      return <RunningIcon />;
+    case 'error':
+      return <ErrorIcon />;
+    case 'pending':
+      return <PendingIcon />;
+  }
+}
+
+export default function AnalysisSteps({ steps, collapsed }: AnalysisStepsProps) {
+  const [expandedDetail, setExpandedDetail] = useState<string | null>(null);
+  const [forceExpanded, setForceExpanded] = useState(false);
+
+  if (!steps || steps.length === 0) return null;
+
+  const sorted = useMemo(() => {
+    return [...steps].sort((a, b) => a.timestamp - b.timestamp);
+  }, [steps]);
+
+  const totalDuration = useMemo(() => {
+    if (sorted.length <= 1) return null;
+    const duration = (sorted[sorted.length - 1].timestamp - sorted[0].timestamp) / 1000;
+    if (duration <= 0) return null;
+    return duration;
+  }, [sorted]);
+
+  const hasError = sorted.some((s) => s.status === 'error');
+  const allDone = sorted.every((s) => s.status === 'done');
+
+  // Always show expanded view when there are errors, regardless of collapsed prop
+  const isCollapsed = collapsed && !hasError && !forceExpanded && allDone;
+
+  const title = (
+    <span className="flex items-center gap-2 text-sm">
+      <DoneIcon />
+      <span>
+        分析完成 · 共 {sorted.length} 步{totalDuration !== null && ` · 耗时 ${totalDuration.toFixed(1)}s`}
+      </span>
+    </span>
+  );
+
+  if (isCollapsed) {
+    return (
+      <div className="mb-4 p-3 bg-gray-50 rounded-xl border border-gray-100">
+        <button
+          onClick={() => setForceExpanded(true)}
+          className="w-full flex items-center justify-between text-sm text-gray-600 hover:text-gray-800 transition-colors"
+        >
+          {title}
+          <span className="text-[#78d3f8] font-medium flex items-center gap-1">
+            展开
+            <svg
+              className="w-3 h-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-4 p-3 bg-gray-50 rounded-xl border border-gray-100">
+      {/* Header with summary and collapse button when expanded */}
+      {allDone && (
+        <div className="flex items-center justify-between mb-2">
+          {title}
+          <button
+            onClick={() => setForceExpanded(false)}
+            className="text-xs text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-1 flex-shrink-0"
+          >
+            收起
+            <svg
+              className="w-3 h-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="18 15 12 9 6 15" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {sorted.map((step, index) => {
+          const stepTime = getStepTime(step, index, sorted);
+          const isExpanded = expandedDetail === step.id;
+
+          return (
+            <div key={step.id}>
+              <div className={`flex items-center gap-2.5 text-sm ${step.status === 'pending' ? 'opacity-50' : ''}`}>
+                <StepIcon status={step.status} />
+                <span
+                  className={`flex-1 ${
+                    step.status === 'done'
+                      ? 'text-gray-700'
+                      : step.status === 'running'
+                      ? 'text-gray-800 font-medium'
+                      : step.status === 'error'
+                      ? 'text-red-600'
+                      : 'text-gray-400'
+                  }`}
+                >
+                  {step.label}
+                </span>
+
+                {stepTime && <span className="text-xs text-gray-400">{stepTime}</span>}
+
+                {/* View/Hide button for done steps with detail */}
+                {step.status === 'done' && step.detail && (
+                  <button
+                    onClick={() => setExpandedDetail(isExpanded ? null : step.id)}
+                    className={`text-xs font-medium transition-colors flex items-center gap-1 flex-shrink-0 ${
+                      isExpanded ? 'text-[#78d3f8]' : 'text-gray-400 hover:text-[#78d3f8]'
+                    }`}
+                  >
+                    {isExpanded ? '收起' : '查看'}
+                    <svg
+                      className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polyline points="6 9 12 15 18 9" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+
+              {/* Error message */}
+              {step.status === 'error' && step.error && (
+                <div className="mt-1 ml-6.5 text-xs text-red-500">{step.error}</div>
+              )}
+
+              {/* Expanded detail code block */}
+              {isExpanded && step.detail && (
+                <div className="mt-1.5 ml-6.5">
+                  <pre className="p-3 bg-gray-900 text-gray-100 rounded-lg text-xs overflow-x-auto font-mono leading-relaxed">
+                    {step.detail}
+                  </pre>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/site/components/GPTVisRenderer.tsx
+++ b/site/components/GPTVisRenderer.tsx
@@ -31,7 +31,7 @@ const GPTVisRenderer: React.FC<GPTVisRendererProps> = ({ syntax, width, height, 
       instance.destroy();
       instanceRef.current = null;
     };
-  }, []);
+  }, [width, height]);
 
   // Update: re-render when syntax or dimensions change.
   useEffect(() => {

--- a/site/components/Visualization.tsx
+++ b/site/components/Visualization.tsx
@@ -3,10 +3,11 @@ import React, { useState, useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { AVA } from '@antv/ava';
-import type { AnalysisResponse } from '@antv/ava';
+import type { AnalysisResponse, AnalysisStep } from '@antv/ava';
 import type { DataRow } from './types';
 import { loadAppState, saveAppState } from './utils';
 import GPTVisRenderer from './GPTVisRenderer';
+import AnalysisSteps from './AnalysisSteps';
 
 interface VisualizationProps {
   avaInstance: AVA | null;
@@ -21,6 +22,7 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
   const [result, setResult] = useState<AnalysisResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
+  const [steps, setSteps] = useState<AnalysisStep[]>([]);
 
   // Restore query and result from localStorage on mount
   useEffect(() => {
@@ -45,10 +47,14 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
 
     setIsLoading(true);
     setError(null);
+    setSteps([]);  // Clear old steps on new analysis
 
     try {
-      // Use the global AVA instance's analysis method to process the query
-      const analysisResult = await avaInstance.analysis(query);
+      const analysisResult = await avaInstance.analysis(query, {
+        onProgress: (steps) => {
+          setSteps(steps);
+        },
+      });
       setResult(analysisResult);
 
       // Save to localStorage
@@ -168,6 +174,11 @@ const Visualization: React.FC<VisualizationProps> = ({ avaInstance, data, isInit
         >
           {error}
         </div>
+      )}
+
+      {/* Analysis Progress Steps */}
+      {steps.length > 0 && (
+        <AnalysisSteps steps={steps} collapsed={!isLoading} />
       )}
 
       {/* Analysis Summary - Always show when result.text exists, rendered with react-markdown */}

--- a/src/ava.ts
+++ b/src/ava.ts
@@ -34,12 +34,12 @@ enum STEP_PHASE {
 }
 
 const STEP_LABEL: Record<STEP_PHASE, string> = {
-  [STEP_PHASE.SQL_CODE]: '生成查询代码',
-  [STEP_PHASE.JS_CODE]: '生成分析代码',
-  [STEP_PHASE.EXECUTE]: '执行分析',
-  [STEP_PHASE.SUMMARIZE]: '生成分析摘要',
-  [STEP_PHASE.ADVISOR]: '检测图表类型',
-  [STEP_PHASE.VISUALIZE]: '生成可视化',
+  [STEP_PHASE.SQL_CODE]: 'Generate SQL query',
+  [STEP_PHASE.JS_CODE]: 'Generate analysis code',
+  [STEP_PHASE.EXECUTE]: 'Execute analysis',
+  [STEP_PHASE.SUMMARIZE]: 'Generate analysis summary',
+  [STEP_PHASE.ADVISOR]: 'Detect chart type',
+  [STEP_PHASE.VISUALIZE]: 'Generate visualization',
 };
 
 const createStepEmitter = (onProgress: AnalysisProgressCallback | undefined) => {
@@ -209,7 +209,7 @@ export class AVA {
         analysisData = await this.sqliteStore.query(sql);
         progress({
           phase: STEP_PHASE.EXECUTE,
-          params: { status: 'done', detail: `返回 ${analysisData.length} 条记录` },
+          params: { status: 'done', detail: `Returned ${analysisData.length} records` },
         });
       } catch (error) {
         progress({
@@ -253,7 +253,7 @@ export class AVA {
         analysisData = await executeDataCode(this.data, code);
         progress({
           phase: STEP_PHASE.EXECUTE,
-          params: { status: 'done', detail: `返回 ${analysisData.length} 条记录` },
+          params: { status: 'done', detail: `Returned ${analysisData.length} records` },
         });
       } catch (error) {
         progress({
@@ -279,7 +279,7 @@ export class AVA {
       progress({ phase: STEP_PHASE.ADVISOR, params: { status: 'running' } });
       // adviseChartType uses describeData which handles any data format
       const chartType = await adviseChartType(query, analysisData, this.llmConfig);
-      progress({ phase: STEP_PHASE.ADVISOR, params: { status: 'done', detail: chartType || '无需可视化' } });
+      progress({ phase: STEP_PHASE.ADVISOR, params: { status: 'done', detail: chartType || 'No visualization needed' } });
 
       if (chartType && hasData(analysisData)) {
         // generateVisualizationHTML uses JSON.stringify which handles any JSON-serializable data

--- a/src/ava.ts
+++ b/src/ava.ts
@@ -6,21 +6,76 @@ import { generateText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 
 import { loadCSV, loadObject, loadURL, loadText, extractMetadata, formatDatasetInfo } from './data';
-import {
-  SQLiteDataStore,
-  executeDataCode,
-  generateSQL,
-  generateDataCode,
-} from './analysis';
-import {
-  adviseChartType,
-  generateVisualizationHTML,
-} from './visualization';
+import { SQLiteDataStore, executeDataCode, generateSQL, generateDataCode } from './analysis';
+import { adviseChartType, generateVisualizationHTML } from './visualization';
 import { generateSuggestions } from './suggest';
 
-import type { AVAConfig, LLMConfig, DatasetInfo, AnalysisResponse, SuggestResult } from './types';
+import type {
+  AVAConfig,
+  LLMConfig,
+  DatasetInfo,
+  AnalysisResponse,
+  AnalysisOptions,
+  SuggestResult,
+  AnalysisProgressCallback,
+  StepEmitterParams,
+  AnalysisStep,
+} from './types';
 
 const DEFAULT_SQL_THRESHOLD = 10 * 1024; // 10KB
+
+enum STEP_PHASE {
+  SQL_CODE = 'sqlCode',
+  JS_CODE = 'jsCode',
+  EXECUTE = 'execute',
+  SUMMARIZE = 'summarize',
+  ADVISOR = 'advisor',
+  VISUALIZE = 'visualize',
+}
+
+const STEP_LABEL: Record<STEP_PHASE, string> = {
+  [STEP_PHASE.SQL_CODE]: '生成查询代码',
+  [STEP_PHASE.JS_CODE]: '生成分析代码',
+  [STEP_PHASE.EXECUTE]: '执行分析',
+  [STEP_PHASE.SUMMARIZE]: '生成分析摘要',
+  [STEP_PHASE.ADVISOR]: '检测图表类型',
+  [STEP_PHASE.VISUALIZE]: '生成可视化',
+};
+
+const createStepEmitter = (onProgress: AnalysisProgressCallback | undefined) => {
+  let id = 0;
+  const steps: AnalysisStep[] = [];
+
+  return (params: StepEmitterParams | StepEmitterParams[]) => {
+    const items = Array.isArray(params) ? params : [params];
+    for (const item of items) {
+      const existingIdx = steps.findIndex((s) => s.phase === item.phase);
+      const label = STEP_LABEL[item.phase as STEP_PHASE];
+
+      if (existingIdx !== -1) {
+        steps[existingIdx] = {
+          ...steps[existingIdx],
+          status: item.params.status,
+          timestamp: Date.now(),
+          detail: item.params.detail,
+          error: item.params.error,
+        };
+      } else {
+        steps.push({
+          id: String(id++),
+          agent: 'main',
+          phase: item.phase,
+          label,
+          status: item.params.status,
+          timestamp: Date.now(),
+          detail: item.params.detail,
+          error: item.params.error,
+        });
+      }
+    }
+    onProgress?.([...steps]);
+  };
+};
 
 /**
  * Check if analysis result has meaningful data for visualization.
@@ -114,11 +169,14 @@ export class AVA {
   /**
    * Analyze data using natural language query
    */
-  async analysis(query: string): Promise<AnalysisResponse> {
+  async analysis(query: string, options?: AnalysisOptions): Promise<AnalysisResponse> {
     if (!this.dataInfo) {
-      throw new Error('No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).');
+      throw new Error(
+        'No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).'
+      );
     }
 
+    const progress = createStepEmitter(options?.onProgress);
     let analysisData: any = undefined;
     let analysisCode: string | undefined;
     let analysisSql: string | undefined;
@@ -126,15 +184,42 @@ export class AVA {
     // Use SQLite for large datasets
     if (this.sqliteStore) {
       const schema = await this.sqliteStore.getSchema();
-      const sql = await generateSQL(this.llmConfig, schema, query);
+
+      progress({ phase: STEP_PHASE.SQL_CODE, params: { status: 'running' } });
+      let sql: string;
+      try {
+        sql = await generateSQL(this.llmConfig, schema, query);
+      } catch (error) {
+        progress({
+          phase: STEP_PHASE.SQL_CODE,
+          params: {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+        throw error;
+      }
       analysisSql = sql;
+      progress([
+        { phase: STEP_PHASE.SQL_CODE, params: { status: 'done', detail: sql } },
+        { phase: STEP_PHASE.EXECUTE, params: { status: 'running' } },
+      ]);
 
       try {
         analysisData = await this.sqliteStore.query(sql);
+        progress({
+          phase: STEP_PHASE.EXECUTE,
+          params: { status: 'done', detail: `返回 ${analysisData.length} 条记录` },
+        });
       } catch (error) {
-        throw new Error(
-          `Failed to execute SQL query: ${error instanceof Error ? error.message : String(error)}`
-        );
+        progress({
+          phase: STEP_PHASE.EXECUTE,
+          params: {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+        throw new Error(`Failed to execute SQL query: ${error instanceof Error ? error.message : String(error)}`);
       }
     } else {
       // Use JavaScript for small datasets
@@ -143,32 +228,72 @@ export class AVA {
       }
 
       const dataInfoStr = formatDatasetInfo(this.dataInfo);
-      const code = await generateDataCode(this.llmConfig, dataInfoStr, query);
+
+      progress({ phase: STEP_PHASE.JS_CODE, params: { status: 'running' } });
+      let code: string;
+      try {
+        code = await generateDataCode(this.llmConfig, dataInfoStr, query);
+      } catch (error) {
+        progress({
+          phase: STEP_PHASE.JS_CODE,
+          params: {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+        throw error;
+      }
       analysisCode = code;
+      progress([
+        { phase: STEP_PHASE.JS_CODE, params: { status: 'done', detail: code } },
+        { phase: STEP_PHASE.EXECUTE, params: { status: 'running' } },
+      ]);
 
       try {
         analysisData = await executeDataCode(this.data, code);
+        progress({
+          phase: STEP_PHASE.EXECUTE,
+          params: { status: 'done', detail: `返回 ${analysisData.length} 条记录` },
+        });
       } catch (error) {
-        throw new Error(
-          `Failed to execute data code: ${error instanceof Error ? error.message : String(error)}`
-        );
+        progress({
+          phase: STEP_PHASE.EXECUTE,
+          params: {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+        throw new Error(`Failed to execute data code: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
 
     // Summarize the result using LLM
+    progress({ phase: STEP_PHASE.SUMMARIZE, params: { status: 'running' } });
     const summary = await this.summarizeResult(query, analysisData);
+    progress({ phase: STEP_PHASE.SUMMARIZE, params: { status: 'done', detail: summary.slice(0, 200) } });
 
     // Detect visualization intent and generate visualization if needed
     let visualizationHTML: string | undefined;
     let visualizationSyntax: string | undefined;
     try {
+      progress({ phase: STEP_PHASE.ADVISOR, params: { status: 'running' } });
       // adviseChartType uses describeData which handles any data format
       const chartType = await adviseChartType(query, analysisData, this.llmConfig);
+      progress({ phase: STEP_PHASE.ADVISOR, params: { status: 'done', detail: chartType || '无需可视化' } });
+
       if (chartType && hasData(analysisData)) {
         // generateVisualizationHTML uses JSON.stringify which handles any JSON-serializable data
+        progress({ phase: STEP_PHASE.VISUALIZE, params: { status: 'running' } });
         const result = await generateVisualizationHTML(chartType, analysisData, query, this.llmConfig);
         visualizationSyntax = result.syntax;
         visualizationHTML = result.html;
+        progress({
+          phase: STEP_PHASE.VISUALIZE,
+          params: {
+            status: 'done',
+            detail: visualizationSyntax ? visualizationSyntax.slice(0, 200) : '',
+          },
+        });
       }
     } catch (error) {
       // Visualization is optional, don't fail the analysis if it fails
@@ -222,7 +347,9 @@ Provide a natural language summary of the result. If the result is tabular data,
    */
   async suggest(count: number = 3): Promise<SuggestResult[]> {
     if (!this.dataInfo) {
-      throw new Error('No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).');
+      throw new Error(
+        'No data loaded. Please call one of the load methods first (loadCSV, loadObject, loadURL, or loadText).'
+      );
     }
 
     return generateSuggestions(this.llmConfig, this.dataInfo, count);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
 /**
  * AVA v4 - A framework for AI-native Visual Analytics
- * 
+ *
  * Main entry point
  */
 export { AVA } from './ava';
-export type { AVAConfig, LLMConfig, AnalysisResponse, AnalysisStep, StepStatus, DatasetInfo, FieldMetadata, ChartType, SuggestResult } from './types';
+export type {
+  AVAConfig,
+  LLMConfig,
+  AnalysisResponse,
+  AnalysisStep,
+  StepStatus,
+  DatasetInfo,
+  FieldMetadata,
+  ChartType,
+  SuggestResult,
+} from './types';
 export { loadCSV, loadObject, loadURL, loadText, extractMetadata, formatDatasetInfo } from './data';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,5 @@
  * Main entry point
  */
 export { AVA } from './ava';
-export type { AVAConfig, LLMConfig, AnalysisResponse, DatasetInfo, FieldMetadata, ChartType, SuggestResult } from './types';
+export type { AVAConfig, LLMConfig, AnalysisResponse, AnalysisStep, StepStatus, DatasetInfo, FieldMetadata, ChartType, SuggestResult } from './types';
 export { loadCSV, loadObject, loadURL, loadText, extractMetadata, formatDatasetInfo } from './data';

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,3 +110,49 @@ export interface SuggestResult {
   /** Reason for the score */
   reason: string;
 }
+
+/**
+ * Status of a single analysis step
+ */
+export type StepStatus = 'pending' | 'running' | 'done' | 'error';
+
+/**
+ * A single analysis step
+ * Designed to be JSON-serializable for history storage
+ */
+export interface AnalysisStep {
+  /** Unique step ID */
+  id: string;
+  /** Agent identifier, reserved for multi-agent scenarios. Currently fixed as 'main' */
+  agent: string;
+  /** Step phase identifier, such as 'code', 'execute', 'summarize', 'advisor', 'visualize' */
+  phase: string;
+  /** Short label for UI display, e.g., "Generate analysis code" */
+  label: string;
+  /** Current step status */
+  status: StepStatus;
+  /** Optional: raw output summary, shown when user clicks "view" */
+  detail?: string;
+  /** Optional: error message when step fails */
+  error?: string;
+  /** Unix millisecond timestamp, updated on step status change */
+  timestamp: number;
+}
+
+/**
+ * Progress callback function type
+ */
+export type AnalysisProgressCallback = (steps: AnalysisStep[]) => void;
+
+/**
+ * Parameters for emitting a single analysis step
+ */
+export type StepEmitterParams = { phase: string; params: { status: StepStatus; detail?: string; error?: string } };
+
+/**
+ * Extended options for the analysis() method
+ */
+export interface AnalysisOptions {
+  /** Progress callback, pushes analysis progress step by step */
+  onProgress?: AnalysisProgressCallback;
+}


### PR DESCRIPTION
新开分支实现 https://github.com/antvis/AVA/pull/958


以下是原PR描述


=============================================
<img width="1090" height="495" alt="image" src="https://github.com/user-attachments/assets/409bec40-0c84-4686-a7d5-7d9599f4a448" />


点击 Generate 后，只有按钮变成loading，没有其他的提示了，用户只能干等着，不清楚运行情况，加上了分析步骤

## 变动                                                                                                                   
### 分析流程改造 (`src/ava.ts`)
                                         
- `analysis()` 方法新增 `options?: AnalysisOptions` 参数，支持 `onProgress` 回调
- 新增 `createStepEmitter` 工厂函数：内部维护步骤数组，按 phase 去重（同 phase 状态更新而非新增），每次 emit 后回调传出完整的 `AnalysisStep[]`
- 每个分析阶段（SQL/JS 代码生成 → 执行 → 摘要 → 图表类型检测 → 可视化生成）都有进度上报，覆盖 running / done / error 三种状态

### 进度组件 (`site/components/AnalysisSteps.tsx`)                                                                    
   
- 可折叠的步骤进度面板，显示步骤名称、状态图标、耗时、错误信息                                                        
- 完成态默认收起为摘要行（"分析完成 · 共 N 步 · 耗时 Xs"），可展开查看详情
 - 每个步骤的 detail（代码 / SQL / 摘要）可点击查看/收起

### Site 集成 (`site/components/Visualization.tsx`)

- 分析请求时传递 `onProgress` 回调，驱动 `AnalysisSteps` 实时更新